### PR TITLE
Add a /tasks API

### DIFF
--- a/app/controllers/api/v0/tasks_controller.rb
+++ b/app/controllers/api/v0/tasks_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V0
+    class TasksController < ApplicationController
+      include Api::Mixins::IndexMixin
+      include Api::Mixins::ShowMixin
+
+      def list_params
+        params.permit(:tenant_id)
+      end
+
+      def model
+        Task
+      end
+    end
+  end
+end

--- a/app/controllers/api/v0x0.rb
+++ b/app/controllers/api/v0x0.rb
@@ -9,5 +9,6 @@ module Api
     class ServiceOfferingsController < Api::V0::ServiceOfferingsController; end
     class ServicePlansController < Api::V0::ServicePlansController; end
     class SourcesController < Api::V0::SourcesController; end
+    class TasksController < Api::V0::TasksController; end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
         resources :service_offerings,       :only => [:index]
         resources :service_plans, :only => [:index]
       end
+      resources :tasks, :only => [:index, :show]
     end
   end
 end

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -781,6 +781,41 @@ paths:
           description: Source deleted
         404:
           description: Not found
+  "/tasks":
+    get:
+      summary: List Tasks
+      operationId: listTasks
+      description: Returns an array of Task objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Tasks array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Task"
+  "/tasks/{id}":
+    get:
+      summary: Show an existing Task
+      operationId: showTask
+      description: Returns a Task object
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        description: ID of the resource to return
+        required: true
+        type: string
+        pattern: '\A\d+\z'
+      responses:
+        200:
+          description: Task info
+          schema:
+            "$ref": "#/definitions/Task"
+        404:
+          description: Not found
 definitions:
   ContainerGroup:
     type: object
@@ -1128,6 +1163,36 @@ definitions:
         type: string
         readOnly: true
         title: Unique ID of the inventory source installation
+      tenant_id:
+        type: string
+        readOnly: true
+        format: uuid
+  Task:
+    type: object
+    properties:
+      id:
+        type: string
+        readOnly: true
+        format: uuid
+      name:
+        type: string
+        example: Order Service Plan
+        title: Name
+      status:
+        type: string
+        example: Error
+        title: Status
+      state:
+        type: string
+        example: Running
+        title: State
+      context:
+        type: object
+        example: Extra information about this task, e.g. new inventory items created by this task
+        title: Context
+      completed_at:
+        type: string
+        format: date-time
       tenant_id:
         type: string
         readOnly: true

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -26,6 +26,7 @@ describe "Swagger stuff" do
     let(:service_offering) { ServiceOffering.create!(doc.example_attributes("ServiceOffering").symbolize_keys.merge(:tenant => tenant, :source => source, :source_ref => SecureRandom.uuid, :source_created_at => Time.now)) }
     let(:service_plan) { ServicePlan.create!(doc.example_attributes("ServicePlan").symbolize_keys.merge(:tenant => tenant, :source => source, :service_offering => service_offering, :source_ref => SecureRandom.uuid, :source_created_at => Time.now, :create_json_schema => {}, :update_json_schema => {})) }
     let(:source) { Source.create!(doc.example_attributes("Source").symbolize_keys.merge(:tenant => tenant, :uid => SecureRandom.uuid)) }
+    let(:task) { Task.create!(:tenant => tenant, :name => "Operation", :status => "Ok", :state => "Running", :completed_at => Time.now.utc, :context => {:method => "order"}) }
     let(:tenant) { Tenant.create! }
 
     context "v0.0" do


### PR DESCRIPTION
Add an API for Tasks and update swagger.yaml

```
http://localhost:3000/api/v0.0/tasks
[{"id":"1","name":"Order Service Plan","status":null,"state":null,"message":null,"progress":null,"tenant_id":1,"created_at":"2018-10-26T20:08:34.643Z","updated_at":"2018-10-26T20:08:34.643Z"}]

http://localhost:3000/api/v0.0/tasks/1
{"id":"1","name":"Order Service Plan","status":null,"state":null,"message":null,"progress":null,"tenant_id":1,"created_at":"2018-10-26T20:08:34.643Z","updated_at":"2018-10-26T20:08:34.643Z"}
```

~~Depends: https://github.com/ManageIQ/topological_inventory-core/pull/36~~