### PR TITLE
Customizable routes path prefix

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-  namespace :api do
+  prefix = ENV["PATH_PREFIX"] || "api"
+  scope :as => :api, :module => "api", :path => prefix do
     namespace :v0x0, :path => "v0.0" do
       resources :container_groups,        :only => [:index, :show]
       resources :container_nodes,         :only => [:index, :show] do

--- a/spec/controllers/api/v0x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x0/endpoints_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V0x0::EndpointsController, :type => :request do
     endpoint = Endpoint.first
 
     expect(response.status).to eq(201)
-    expect(response.location).to match(a_string_ending_with("api/v0.0/endpoints/#{endpoint.id}"))
+    expect(response.location).to match(a_string_ending_with("v0.0/endpoints/#{endpoint.id}"))
     expect(response.parsed_body).to include("host" => "example.com", "id" => endpoint.id.to_s)
   end
 end

--- a/spec/controllers/api/v0x0/sources_controller_spec.rb
+++ b/spec/controllers/api/v0x0/sources_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V0x0::SourcesController, :type => :request do
     source = Source.first
 
     expect(response.status).to eq(201)
-    expect(response.location).to match(a_string_ending_with("api/v0.0/sources/#{source.id}"))
+    expect(response.location).to match(a_string_ending_with("v0.0/sources/#{source.id}"))
     expect(response.parsed_body).to include("name" => "abc", "id" => source.id.to_s)
   end
 end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -11,8 +11,36 @@ describe "Swagger stuff" do
 
   let(:swagger_routes) { Api::Docs.routes }
 
-  it "routes match" do
-    expect(rails_routes).to match_array(swagger_routes)
+  describe "Routing" do
+    include Rails.application.routes.url_helpers
+
+    it "routes match" do
+      expect(rails_routes).to match_array(swagger_routes)
+    end
+
+    context "customizable route prefixes" do
+      after { Rails.application.reload_routes! }
+
+      it "with a random prefix" do
+        stub_const("ENV", ENV.to_h.merge("PATH_PREFIX" => random_path))
+        Rails.application.reload_routes!
+
+        expect(ENV["PATH_PREFIX"]).not_to be_nil
+        expect(api_v0x0_sources_url(:only_path => true)).to eq("/#{ENV["PATH_PREFIX"]}/v0.0/sources")
+      end
+    end
+
+    def words
+      @words ||= File.readlines("/usr/share/dict/words", :chomp => true)
+    end
+
+    def random_path_part
+      rand(1..5).times.collect { words.sample }.join("_")
+    end
+
+    def random_path
+      rand(1..10).times.collect { random_path_part }.join("/")
+    end
   end
 
   describe "Model serialization" do


### PR DESCRIPTION
Allow for ENV["PATH_PREFIX"] to change the base path for the api routes.