### PR TITLE
Redirect major path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   prefix = ENV["PATH_PREFIX"] || "api"
   scope :as => :api, :module => "api", :path => prefix do
+    match "/v0/*path", :via => [:delete, :get, :options, :patch, :post, :put], :to => redirect("#{prefix}/v0.0/%{path}")
+
     namespace :v0x0, :path => "v0.0" do
       resources :container_groups,        :only => [:index, :show]
       resources :container_nodes,         :only => [:index, :show] do

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -15,7 +15,8 @@ describe "Swagger stuff" do
     include Rails.application.routes.url_helpers
 
     it "routes match" do
-      expect(rails_routes).to match_array(swagger_routes)
+      redirect_routes = [{:path=>"/api/v0/*path", :verb=>"DELETE|GET|OPTIONS|PATCH|POST|PUT"}]
+      expect(rails_routes).to match_array(swagger_routes + redirect_routes)
     end
 
     context "customizable route prefixes" do


### PR DESCRIPTION
If someone attempts to use /v0/*, redirect them to the latest current v0.x version.

Based on changes in https://github.com/ManageIQ/topological_inventory-api/pull/32