### PR TITLE
Add order endpoint for service_plans

### DIFF
--- a/app/controllers/api/v0/service_plans_controller.rb
+++ b/app/controllers/api/v0/service_plans_controller.rb
@@ -7,7 +7,7 @@ module Api
       def order
         service_plan = model.find(params[:service_plan_id])
         catalog_parameters = params[:service_parameters].permit!.merge(params[:provider_control_parameters].permit!)
-        task_id = service_plan.order(params[:catalog_id], catalog_parameters)
+        task_id = service_plan.order(catalog_parameters)
         render :json => {:task_id => task_id}
       end
 

--- a/app/controllers/api/v0/service_plans_controller.rb
+++ b/app/controllers/api/v0/service_plans_controller.rb
@@ -5,8 +5,9 @@ module Api
       include Api::Mixins::ShowMixin
 
       def order
-        service_plan = model.find(params[:id])
-        task_id = service_plan.order(params[:catalog_id], params[:other_params?])
+        service_plan = model.find(params[:service_plan_id])
+        catalog_parameters = params[:service_parameters].permit!.merge(params[:provider_control_parameters].permit!)
+        task_id = service_plan.order(params[:catalog_id], catalog_parameters)
         render :json => {:task_id => task_id}
       end
 

--- a/app/controllers/api/v0/service_plans_controller.rb
+++ b/app/controllers/api/v0/service_plans_controller.rb
@@ -5,13 +5,29 @@ module Api
       include Api::Mixins::ShowMixin
 
       def order
-        service_plan = model.find(params[:service_plan_id])
-        catalog_parameters = params[:service_parameters].permit!.merge(params[:provider_control_parameters].permit!)
+        service_plan = model.find(service_plan_id)
         task_id = service_plan.order(catalog_parameters)
         render :json => {:task_id => task_id}
+      rescue ActiveRecord::RecordNotFound
+        head :bad_request
       end
 
       private
+
+      def catalog_parameters
+        order_params[:service_parameters].merge(order_params[:provider_control_parameters])
+      end
+
+      def service_plan_id
+        params[:service_plan_id].to_i
+      end
+
+      def order_params
+        params.permit(
+          :service_parameters          => [:DB_NAME, :namespace],
+          :provider_control_parameters => [:namespace, :OpenShift_param1]
+        ).to_h
+      end
 
       def list_params
         params.permit(:source_id, :tenant_id, :service_offering_id)

--- a/app/controllers/api/v0/service_plans_controller.rb
+++ b/app/controllers/api/v0/service_plans_controller.rb
@@ -4,6 +4,12 @@ module Api
       include Api::Mixins::IndexMixin
       include Api::Mixins::ShowMixin
 
+      def order
+        service_plan = model.find(params[:id])
+        task_id = service_plan.order(params[:catalog_id], params[:other_params?])
+        render :json => {:task_id => task_id}
+      end
+
       private
 
       def list_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       resources :source_types, :only => [:create, :index, :show] do
         resources :sources, :only => [:index]
       end
+      post "/service_plans/:id", :to => "service_plans#order"
       resources :sources,                 :only => [:create, :destroy, :index, :show, :update] do
         resources :container_groups,        :only => [:index]
         resources :container_nodes,         :only => [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,12 +21,12 @@ Rails.application.routes.draw do
       end
       resources :orchestration_stacks, :only => [:index, :show]
       resources :service_plans, :only => [:index, :show] do
+        post "order", :to => "service_plans#order"
         resources :service_instances, :only => [:index]
       end
       resources :source_types, :only => [:create, :index, :show] do
         resources :sources, :only => [:index]
       end
-      post "/service_plans/:id", :to => "service_plans#order"
       resources :sources,                 :only => [:create, :destroy, :index, :show, :update] do
         resources :container_groups,        :only => [:index]
         resources :container_nodes,         :only => [:index]

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -3,18 +3,33 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
   it("Uses ShowMixin")  { expect(described_class.instance_method(:show).owner).to eq(Api::Mixins::ShowMixin) }
 
   describe "#order" do
-    let(:service_plan) { instance_double("ServicePlan", :id => 123) }
+    let(:service_plan) { ServicePlan.new(:id => 123) }
+
+    let(:catalog_parameters) { service_parameters.merge(provider_control_parameters) }
+    let(:service_parameters) { {"DB_NAME" => "TEST_DB", "namespace" => "TEST_DB_NAMESPACE"} }
+    let(:provider_control_parameters) { {"namespace" => "test_project", "OpenShift_param1" => "test"} }
 
     before do
-      allow(ServicePlan).to receive(:find).with(123).and_return(service_plan)
-      allow(service_plan).to receive(:order).with(321, "other params").and_return("task_id")
+      allow(ServicePlan).to receive(:find).with("123").and_return(service_plan)
+      allow(service_plan).to receive(:order).with("321", catalog_parameters).and_return("task_id")
+      Rails.application.config.action_dispatch.show_exceptions = false
+    end
+
+    after do
+      Rails.application.config.action_dispatch.show_exceptions = true
     end
 
     it "returns json with the task id" do
-      payload = {:id => 123, :catalog_id => 321, :other_params? => "other params"}.to_json
-      post "order", :params => payload, :format => "json"
+      payload = {
+        :catalog_id                   => 321,
+        "service_parameters"          => service_parameters,
+        "provider_control_parameters" => provider_control_parameters
+      }
+
+      post "/api/v0.0/service_plans/123/order", :params => payload
+
       body = JSON.parse(response.body)
-      expect(body[:task_id]).to eq("task_id")
+      expect(body["task_id"]).to eq("task_id")
     end
   end
 end

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
         :subscription     => subscription
       )
     end
-    let(:source_type) { SourceType.create! }
+    let(:source_type) do
+      SourceType.create!(:name => "source_type", :product_name => "product_name", :vendor => "vendor")
+    end
     let(:source_region) { SourceRegion.create!(:tenant => tenant, :source => source) }
     let(:source) { Source.create!(:tenant => tenant, :source_type => source_type) }
     let(:tenant) { Tenant.create! }
@@ -27,11 +29,6 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
 
     before do
       allow_any_instance_of(ServicePlan).to receive(:order).with(catalog_parameters).and_return("task_id")
-      Rails.application.config.action_dispatch.show_exceptions = false
-    end
-
-    after do
-      Rails.application.config.action_dispatch.show_exceptions = true
     end
 
     it "returns json with the task id" do

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -1,4 +1,20 @@
 RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
   it("Uses IndexMixin") { expect(described_class.instance_method(:index).owner).to eq(Api::Mixins::IndexMixin) }
   it("Uses ShowMixin")  { expect(described_class.instance_method(:show).owner).to eq(Api::Mixins::ShowMixin) }
+
+  describe "#order" do
+    let(:service_plan) { instance_double("ServicePlan", :id => 123) }
+
+    before do
+      allow(ServicePlan).to receive(:find).with(123).and_return(service_plan)
+      allow(service_plan).to receive(:order).with(321, "other params").and_return("task_id")
+    end
+
+    it "returns json with the task id" do
+      payload = {:id => 123, :catalog_id => 321, :other_params? => "other params"}.to_json
+      post "order", :params => payload, :format => "json"
+      body = JSON.parse(response.body)
+      expect(body[:task_id]).to eq("task_id")
+    end
+  end
 end

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
 
     before do
       allow(ServicePlan).to receive(:find).with("123").and_return(service_plan)
-      allow(service_plan).to receive(:order).with("321", catalog_parameters).and_return("task_id")
+      allow(service_plan).to receive(:order).with(catalog_parameters).and_return("task_id")
       Rails.application.config.action_dispatch.show_exceptions = false
     end
 
@@ -21,7 +21,6 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
 
     it "returns json with the task id" do
       payload = {
-        :catalog_id                   => 321,
         "service_parameters"          => service_parameters,
         "provider_control_parameters" => provider_control_parameters
       }

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -16,23 +16,28 @@ describe "Swagger stuff" do
 
     it "routes match" do
       redirect_routes = [{:path=>"/api/v0/*path", :verb=>"DELETE|GET|OPTIONS|PATCH|POST|PUT"}]
-      expect(rails_routes).to match_array(swagger_routes + redirect_routes)
+      additional_routes = [{:path => "/api/v0.0/service_plans/:id/order", :verb => "POST"}]
+      expect(rails_routes).to match_array(swagger_routes + redirect_routes + additional_routes)
     end
 
     context "customizable route prefixes" do
-      after { Rails.application.reload_routes! }
-
-      it "with a random prefix" do
+      before do
         stub_const("ENV", ENV.to_h.merge("PATH_PREFIX" => random_path))
         Rails.application.reload_routes!
+      end
 
+      after(:all) do
+        Rails.application.reload_routes!
+      end
+
+      it "with a random prefix" do
         expect(ENV["PATH_PREFIX"]).not_to be_nil
         expect(api_v0x0_sources_url(:only_path => true)).to eq("/#{ENV["PATH_PREFIX"]}/v0.0/sources")
       end
     end
 
     def words
-      @words ||= File.readlines("/usr/share/dict/words", :chomp => true)
+      @words ||= File.readlines("/usr/share/dict/words").collect(&:strip)
     end
 
     def random_path_part

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -32,7 +32,7 @@ describe "Swagger stuff" do
 
       it "with a random prefix" do
         expect(ENV["PATH_PREFIX"]).not_to be_nil
-        expect(api_v0x0_sources_url(:only_path => true)).to eq("/#{ENV["PATH_PREFIX"]}/v0.0/sources")
+        expect(api_v0x0_sources_url(:only_path => true)).to eq("/#{URI.encode(ENV["PATH_PREFIX"])}/v0.0/sources")
       end
     end
 


### PR DESCRIPTION
Similar to https://github.com/ManageIQ/topological_inventory-core/pull/39, I don't fully know the structure of the request that will actually be submitted to the `order` endpoint, so I've got some placeholders like `:other_params?`, and I don't know if our response is going to be taking the form of `{:task_id => task_id}` but that is what it is for now.

The specs will fail because for some reason it can't find the "order" action. I think we may need to re-think how we want to layout the routes. If another method comes up on the `ServicePlansController` that isn't a CRUD operation, we would need to add another route anyway, so maybe it's better to change the route to `service_plans/:id/order`. I'm not sure.

@agrare @gtanzillo @bdunne Please review and advise!