### PR TITLE
Remove strict JSON Schema validation

### DIFF
--- a/config/initializers/application_record_serializing.rb
+++ b/config/initializers/application_record_serializing.rb
@@ -10,7 +10,7 @@ ar_serializing = Module.new do
       attrs[name] = attrs[name].iso8601 if attrs[name].kind_of?(Time)
       attrs[name] = attrs[name].to_s if name.ends_with?("_id") || name == "id"
     end
-    attrs
+    attrs.compact
   end
 end
 

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -839,9 +839,7 @@ definitions:
         format: date-time
         readOnly: true
       source_deleted_at:
-        type:
-        - string
-        - null
+        type: string
         format: date-time
         readOnly: true
       container_node_id:
@@ -889,9 +887,7 @@ definitions:
         format: date-time
         readOnly: true
       source_deleted_at:
-        type:
-        - string
-        - null
+        type: string
         format: date-time
         readOnly: true
       source_id:
@@ -949,9 +945,7 @@ definitions:
         format: date-time
         readOnly: true
       source_deleted_at:
-        type:
-        - string
-        - null
+        type: string
         format: date-time
         readOnly: true
       source_id:
@@ -1021,18 +1015,15 @@ definitions:
         example: Sample ServiceInstance
         title: Name
       extra:
-        type:
-        - object
-        - null
+        type: string
+        description: Extra information about this object in JSON format
         readOnly: true
       source_created_at:
         type: string
         format: date-time
         readOnly: true
       source_deleted_at:
-        type:
-        - string
-        - null
+        type: string
         format: date-time
         readOnly: true
       service_offering_id:
@@ -1072,19 +1063,15 @@ definitions:
         title: Source reference
         description: The native reference used by the Source to refer to this object
       extra:
-        type:
-        - object
-        - null
-        example: Extra information about this object in JSON format
-        title: Extra
+        type: string
+        description: Extra information about this object in JSON format
+        readOnly: true
       source_created_at:
         type: string
         format: date-time
         readOnly: true
       source_deleted_at:
-        type:
-        - string
-        - null
+        type: string
         format: date-time
         readOnly: true
       source_id:
@@ -1111,19 +1098,15 @@ definitions:
         example: This is a sample description for a provider
         title: Description
       extra:
-        type:
-        - object
-        - null
-        example: Extra information about this object in JSON format
-        title: Extra
+        type: string
+        description: Extra information about this object in JSON format
+        readOnly: true
       source_created_at:
         type: string
         format: date-time
         readOnly: true
       source_deleted_at:
-        type:
-        - string
-        - null
+        type: string
         format: date-time
         readOnly: true
       source_id:

--- a/spec/support/json_schema_matcher.rb
+++ b/spec/support/json_schema_matcher.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :match_json_schema do |version, schema|
   match do |parsed_body|
     s = Api::Docs[version].definitions[schema]
-    JSON::Validator.validate!(s, parsed_body, :strict => true)
+    JSON::Validator.validate!(s, parsed_body)
   end
 end


### PR DESCRIPTION
Swagger editors can't handle type being an array for some reason