### PR TITLE
Don't .to_s ids in API specs

### DIFF
--- a/spec/controllers/api/v0x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x0/endpoints_controller_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Api::V0x0::EndpointsController, :type => :request do
 
   it "post /endpoints creates an Endpoint" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x0_endpoints_url, :params => {:host => "example.com", :source_id => source.id.to_s, :tenant_id => tenant.id.to_s}.to_json)
+    post(api_v0x0_endpoints_url, :params => {:host => "example.com", :source_id => source.id, :tenant_id => tenant.id}.to_json)
 
     endpoint = Endpoint.first
 
     expect(response.status).to eq(201)
     expect(response.location).to match(a_string_ending_with("v0.0/endpoints/#{endpoint.id}"))
-    expect(response.parsed_body).to include("host" => "example.com", "id" => endpoint.id.to_s)
+    expect(response.parsed_body).to include("host" => "example.com", "id" => endpoint.id)
   end
 end

--- a/spec/controllers/api/v0x0/sources_controller_spec.rb
+++ b/spec/controllers/api/v0x0/sources_controller_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Api::V0x0::SourcesController, :type => :request do
 
   it "post /sources creates a Source" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x0_sources_url, :params => {:source_type_id => source_type.id.to_s, :tenant_id => tenant.id.to_s, :name => "abc"}.to_json)
+    post(api_v0x0_sources_url, :params => {:source_type_id => source_type.id, :tenant_id => tenant.id, :name => "abc"}.to_json)
 
     source = Source.first
 
     expect(response.status).to eq(201)
     expect(response.location).to match(a_string_ending_with("v0.0/sources/#{source.id}"))
-    expect(response.parsed_body).to include("name" => "abc", "id" => source.id.to_s)
+    expect(response.parsed_body).to include("name" => "abc", "id" => source.id)
   end
 end

--- a/spec/controllers/mixins/index_mixin_spec.rb
+++ b/spec/controllers/mixins/index_mixin_spec.rb
@@ -9,7 +9,7 @@ describe Api::Mixins::IndexMixin do
       get(api_v0x0_sources_url)
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body).to match([a_hash_including("id" => source_1.id.to_s), a_hash_including("id" => source_2.id.to_s)])
+      expect(response.parsed_body).to match([a_hash_including("id" => source_1.id), a_hash_including("id" => source_2.id)])
     end
 
     context "Sub-collection:" do
@@ -21,7 +21,7 @@ describe Api::Mixins::IndexMixin do
         get(api_v0x0_source_endpoints_url(source_1.id))
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body).to match([a_hash_including("id" => endpoint_1.id.to_s), a_hash_including("id" => endpoint_2.id.to_s)])
+        expect(response.parsed_body).to match([a_hash_including("id" => endpoint_1.id), a_hash_including("id" => endpoint_2.id)])
       end
     end
   end

--- a/spec/controllers/mixins/show_mixin_spec.rb
+++ b/spec/controllers/mixins/show_mixin_spec.rb
@@ -9,7 +9,7 @@ describe Api::Mixins::ShowMixin do
       get(api_v0x0_source_url(source_1.id))
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body).to include("id" => source_1.id.to_s, "name" => source_1.name)
+      expect(response.parsed_body).to include("id" => source_1.id, "name" => source_1.name)
     end
 
     context "Sub-collection:" do


### PR DESCRIPTION
https://github.com/ManageIQ/topological_inventory-core/pull/53 removed
the `h["id"] = h["id"].to_s` from the ApplicationRecord#as_json method
which is causing the specs to fail.