### PR TITLE
Apparently we are using jbuilder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'jbuilder',    '~> 2.0'
 gem 'json-schema', '~> 2.8'
 gem 'pg',          '~> 1.0', :require => false
 gem 'puma',        '~> 3.0'


### PR DESCRIPTION
It's sending data that we depend on for serialization (specifically `:prefixes`) to `as_json`