### PR TITLE
Prefer webhooks for deployment over Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 ---
 language: ruby
-sudo: required
+sudo: false
 cache: bundler
 rvm:
 - 2.4.5
-services:
-- docker
 addons:
   postgresql: '9.5'
 env:
@@ -20,8 +18,3 @@ before_script:
 - bundle exec rake db:create db:migrate
 after_script:
 - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
-deploy:
-  provider: script
-  script: bash .travis/deploy.sh
-  'on':
-    branch: master

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-TAG="$DEPLOY_SERVER/$DEPLOY_NAMESPACE/$DEPLOY_IMAGE:latest"
-
-echo $DEPLOY_TOKEN | docker login -u $DEPLOY_USER --password-stdin $DEPLOY_SERVER
-docker build -t $TAG .
-docker push $TAG


### PR DESCRIPTION
Working with QE, the preferred way to do deployments for backend stuff is via Webhooks -> BuildConfig -> ImageStream.  We can still use the Docker strategy, so it will do the Docker build, but do it in OpenShift.