### PR TITLE
Add API support for VMs and OrchestrationStacks

### DIFF
--- a/app/controllers/api/v0/orchestration_stacks_controller.rb
+++ b/app/controllers/api/v0/orchestration_stacks_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V0
+    class OrchestrationStacksController < ApplicationController
+      include Api::Mixins::IndexMixin
+      include Api::Mixins::ShowMixin
+
+      private
+
+      def list_params
+        params.permit(:source_id, :tenant_id)
+      end
+
+      def model
+        OrchestrationStack
+      end
+    end
+  end
+end

--- a/app/controllers/api/v0/vms_controller.rb
+++ b/app/controllers/api/v0/vms_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V0
+    class VmsController < ApplicationController
+      include Api::Mixins::IndexMixin
+      include Api::Mixins::ShowMixin
+
+      private
+
+      def list_params
+        params.permit(:source_id, :tenant_id)
+      end
+
+      def model
+        Vm
+      end
+    end
+  end
+end

--- a/app/controllers/api/v0x0.rb
+++ b/app/controllers/api/v0x0.rb
@@ -5,11 +5,13 @@ module Api
     class ContainerProjectsController < Api::V0::ContainerProjectsController; end
     class ContainerTemplatesController < Api::V0::ContainerTemplatesController; end
     class EndpointsController < Api::V0::EndpointsController; end
+    class OrchestrationStacksController < Api::V0::OrchestrationStacksController; end
     class ServiceInstancesController < Api::V0::ServiceInstancesController; end
     class ServiceOfferingsController < Api::V0::ServiceOfferingsController; end
     class ServicePlansController < Api::V0::ServicePlansController; end
     class SourcesController < Api::V0::SourcesController; end
     class SourceTypesController < Api::V0::SourceTypesController; end
     class TasksController < Api::V0::TasksController; end
+    class VmsController < Api::V0::VmsController; end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         resources :service_instances,       :only => [:index]
         resources :service_plans, :only => [:index]
       end
+      resources :orchestration_stacks, :only => [:index, :show]
       resources :service_plans, :only => [:index, :show] do
         resources :service_instances, :only => [:index]
       end
@@ -31,11 +32,14 @@ Rails.application.routes.draw do
         resources :container_projects,      :only => [:index]
         resources :container_templates,     :only => [:index]
         resources :endpoints,               :only => [:index]
+        resources :orchestration_stacks,    :only => [:index]
         resources :service_instances,       :only => [:index]
         resources :service_offerings,       :only => [:index]
         resources :service_plans, :only => [:index]
+        resources :vms,                     :only => [:index]
       end
       resources :tasks, :only => [:index, :show]
+      resources :vms, :only => [:index, :show]
     end
   end
 end

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -331,6 +331,41 @@ paths:
           description: Endpoint deleted
         404:
           description: Not found
+  "/orchestration_stacks":
+    get:
+      summary: List OrchestrationStacks
+      operationId: listOrchestrationStacks
+      description: Returns an array of OrchestrationStack objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: OrchestrationStacks array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/OrchestrationStack"
+  "/orchestration_stacks/{id}":
+    get:
+      summary: Show an existing OrchestrationStack
+      operationId: showOrchestrationStack
+      description: Returns an OrchestrationStack object
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        description: ID of the resource to return
+        required: true
+        type: string
+        pattern: '\A\d+\z'
+      responses:
+        200:
+          description: OrchestrationStack info
+          schema:
+            "$ref": "#/definitions/OrchestrationStack"
+        404:
+          description: Not found
   "/service_instances":
     get:
       summary: List ServiceInstances
@@ -681,6 +716,27 @@ paths:
         required: true
         type: string
         pattern: '\A\d+\z'
+  "/sources/{id}/orchestration_stacks":
+    get:
+      summary: List OrchestrationStacks for Source
+      operationId: listSourceOrchestrationStacks
+      description: Returns an array of OrchestrationStack objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: OrchestrationStacks array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/OrchestrationStack"
+      parameters:
+      - name: id
+        in: path
+        description: ID of the resource to return
+        required: true
+        type: string
+        pattern: '\A\d+\z'
   "/sources/{id}/service_instances":
     get:
       summary: List ServiceInstances for Source
@@ -737,6 +793,27 @@ paths:
             type: array
             items:
               "$ref": "#/definitions/ServicePlan"
+      parameters:
+      - name: id
+        in: path
+        description: ID of the resource to return
+        required: true
+        type: string
+        pattern: '\A\d+\z'
+  "/sources/{id}/vms":
+    get:
+      summary: List Vms for Source
+      operationId: listSourceVms
+      description: Returns an array of Vm objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Vms array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Vm"
       parameters:
       - name: id
         in: path
@@ -891,6 +968,41 @@ paths:
           description: Task info
           schema:
             "$ref": "#/definitions/Task"
+        404:
+          description: Not found
+  "/vms":
+    get:
+      summary: List Vms
+      operationId: listVms
+      description: Returns an array of Vm objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Vms array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Vm"
+  "/vms/{id}":
+    get:
+      summary: Show an existing Vm
+      operationId: showVm
+      description: Returns a Vm object
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        description: ID of the resource to return
+        required: true
+        type: string
+        pattern: '\A\d+\z'
+      responses:
+        200:
+          description: Vm info
+          schema:
+            "$ref": "#/definitions/Vm"
         404:
           description: Not found
 definitions:
@@ -1083,6 +1195,42 @@ definitions:
   Id:
     type: string
     format: uuid
+  OrchestrationStack:
+    type: object
+    properties:
+      id:
+        type: string
+        readOnly: true
+        format: uuid
+      name:
+        type: string
+        example: Sample OrchestrationStack
+        title: Name
+        readOnly: true
+      description:
+        type: string
+        description: Description of the OrchestrationStack
+        readOnly: true
+      source_created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      source_deleted_at:
+        type: string
+        format: date-time
+        readOnly: true
+      source_id:
+        type: string
+        readOnly: true
+        format: uuid
+      source_ref:
+        type: string
+        readOnly: true
+        format: uuid
+      tenant_id:
+        type: string
+        readOnly: true
+        format: uuid
   ServiceInstance:
     type: object
     properties:
@@ -1280,6 +1428,42 @@ definitions:
       completed_at:
         type: string
         format: date-time
+      tenant_id:
+        type: string
+        readOnly: true
+        format: uuid
+  Vm:
+    type: object
+    properties:
+      id:
+        type: string
+        readOnly: true
+        format: uuid
+      name:
+        type: string
+        example: Sample Vm
+        title: Name
+        readOnly: true
+      description:
+        type: string
+        description: Description of the Vm
+        readOnly: true
+      source_created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      source_deleted_at:
+        type: string
+        format: date-time
+        readOnly: true
+      source_id:
+        type: string
+        readOnly: true
+        format: uuid
+      source_ref:
+        type: string
+        readOnly: true
+        format: uuid
       tenant_id:
         type: string
         readOnly: true

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -51,6 +51,7 @@ describe "Swagger stuff" do
     let(:container_project) { ContainerProject.create!(doc.example_attributes("ContainerProject").symbolize_keys.merge(:tenant => tenant, :source => source, :source_ref => SecureRandom.uuid)) }
     let(:container_template) { ContainerTemplate.create!(doc.example_attributes("ContainerTemplate").symbolize_keys.merge(:tenant => tenant, :source => source, :container_project => container_project, :source_created_at => Time.now, :source_ref => SecureRandom.uuid)) }
     let(:endpoint) { Endpoint.create!(doc.example_attributes("Endpoint").symbolize_keys.merge(:tenant => tenant, :source => source)) }
+    let(:orchestration_stack) { OrchestrationStack.create!(doc.example_attributes("OrchestrationStack").symbolize_keys.merge(:tenant => tenant, :source => source)) }
     let(:service_instance) { ServiceInstance.create!(doc.example_attributes("ServiceInstance").symbolize_keys.merge(:tenant => tenant, :source => source, :service_offering => service_offering, :service_plan => service_plan, :source_created_at => Time.now, :source_ref => SecureRandom.uuid, :source_region => source_region, :subscription => subscription)) }
     let(:service_offering) { ServiceOffering.create!(doc.example_attributes("ServiceOffering").symbolize_keys.merge(:tenant => tenant, :source => source, :source_ref => SecureRandom.uuid, :source_created_at => Time.now, :source_region => source_region, :subscription => subscription)) }
     let(:service_plan) { ServicePlan.create!(doc.example_attributes("ServicePlan").symbolize_keys.merge(:tenant => tenant, :source => source, :service_offering => service_offering, :source_ref => SecureRandom.uuid, :source_created_at => Time.now, :create_json_schema => {}, :update_json_schema => {}, :source_region => source_region, :subscription => subscription)) }
@@ -58,6 +59,7 @@ describe "Swagger stuff" do
     let(:source_region) { SourceRegion.create!(:source => source, :tenant => tenant) }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
     let(:subscription) { Subscription.create!(:source => source, :tenant => tenant) }
+    let(:vm) { Vm.create!(doc.example_attributes("Vm").symbolize_keys.merge(:source => source, :tenant => tenant, :source_ref => SecureRandom.uuid, :uid_ems => SecureRandom.uuid)) }
     let(:task) { Task.create!(:tenant => tenant, :name => "Operation", :status => "Ok", :state => "Running", :completed_at => Time.now.utc, :context => {:method => "order"}) }
     let(:tenant) { Tenant.create! }
 


### PR DESCRIPTION
This adds swagger definitions, controllers, and routes for VMs and OrchestrationStacks.

Depends on: https://github.com/ManageIQ/topological_inventory-core/pull/55