### PR TITLE
Add service_plans/{id}/order to swagger.yaml docs

### DIFF
--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -534,6 +534,52 @@ paths:
             "$ref": "#/definitions/ServicePlan"
         404:
           description: Not found
+  "/service_plans/{id}/order":
+    post:
+      summary: Order an existing ServicePlan
+      operationId: orderServicePlan
+      description: Returns a Task id
+      consumes:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        description: ID of the ServicePlan to order
+        required: true
+        type: string
+        pattern: '\A\d+\z'
+      - name: parameters
+        in: body
+        description: Extra parameters defining the service and provider control
+        schema:
+          type: object
+          properties:
+            service_parameters:
+              description: Extra parameters defining the service
+              type: object
+              properties:
+                DB_NAME:
+                  type: string
+                namespace:
+                  type: string
+            provider_control_parameters:
+              description: Extra parameters defining the provider control
+              type: object
+              properties:
+                namespace:
+                  type: string
+                OpenShift_param1:
+                  type: string
+      responses:
+        200:
+          description: Returns a task ID for the order
+          schema:
+            type: object
+            properties:
+              task_id:
+                type: string
+        400:
+          description: BadRequest
   "/source_types/{id}/sources":
     get:
       summary: List Sources for SourceType

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -16,8 +16,7 @@ describe "Swagger stuff" do
 
     it "routes match" do
       redirect_routes = [{:path=>"/api/v0/*path", :verb=>"DELETE|GET|OPTIONS|PATCH|POST|PUT"}]
-      additional_routes = [{:path => "/api/v0.0/service_plans/:id/order", :verb => "POST"}]
-      expect(rails_routes).to match_array(swagger_routes + redirect_routes + additional_routes)
+      expect(rails_routes).to match_array(swagger_routes + redirect_routes)
     end
 
     context "customizable route prefixes" do


### PR DESCRIPTION
An addendum to #37, this adds the definition for the order endpoint in the swagger.yaml.

@agrare Since Brandon is out at the moment, can you take a look and review? I think the only thing that may need changing are some of the descriptions, I don't know enough about the parameters to give a great concise and meaningful one so I feel like they're kind of redundant at the moment, but maybe the names of the properties is kind of self explanatory anyway.