### PR TITLE
Set the Source.uid in API spec tests

### DIFF
--- a/app/controllers/api/v0/sources_controller.rb
+++ b/app/controllers/api/v0/sources_controller.rb
@@ -7,7 +7,7 @@ module Api
       include Api::Mixins::UpdateMixin
 
       def create
-        source = Source.create!(create_params)
+        source = Source.create!(create_params.merge!("uid" => SecureRandom.uuid))
         render :json => source, :status => :created, :location => api_v0x0_source_url(source.id)
       end
 

--- a/spec/controllers/api/v0x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x0/endpoints_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V0x0::EndpointsController, :type => :request do
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::Mixins::ShowMixin) }
   it("Uses UpdateMixin")  { expect(described_class.instance_method(:update).owner).to eq(Api::Mixins::UpdateMixin) }
 
-  let(:source)      { Source.create!(:source_type => source_type, :tenant => tenant) }
+  let(:source)      { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid) }
   let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
   let(:tenant)      { Tenant.create! }
 

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
       SourceType.create!(:name => "source_type", :product_name => "product_name", :vendor => "vendor")
     end
     let(:source_region) { SourceRegion.create!(:tenant => tenant, :source => source) }
-    let(:source) { Source.create!(:tenant => tenant, :source_type => source_type) }
+    let(:source) { Source.create!(:tenant => tenant, :source_type => source_type, :uid => SecureRandom.uuid) }
     let(:tenant) { Tenant.create! }
     let(:subscription) { Subscription.create!(:tenant => tenant, :source => source) }
     let(:service_offering) do

--- a/spec/controllers/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/mixins/destroy_mixin_spec.rb
@@ -1,6 +1,6 @@
 describe Api::Mixins::DestroyMixin do
   describe Api::V0x0::SourcesController, :type => :request do
-    let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1") }
+    let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
     let!(:tenant)     { Tenant.create! }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
 

--- a/spec/controllers/mixins/index_mixin_spec.rb
+++ b/spec/controllers/mixins/index_mixin_spec.rb
@@ -1,7 +1,7 @@
 describe Api::Mixins::IndexMixin do
   describe Api::V0x0::SourcesController, :type => :request do
-    let!(:source_1)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1") }
-    let!(:source_2)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2") }
+    let!(:source_1)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
+    let!(:source_2)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
     let!(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
     let!(:tenant)      { Tenant.create! }
 

--- a/spec/controllers/mixins/show_mixin_spec.rb
+++ b/spec/controllers/mixins/show_mixin_spec.rb
@@ -1,7 +1,7 @@
 describe Api::Mixins::ShowMixin do
   describe Api::V0x0::SourcesController, :type => :request do
-    let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1") }
-    let!(:source_2)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2") }
+    let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
+    let!(:source_2)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
     let!(:tenant)     { Tenant.create! }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
 

--- a/spec/controllers/mixins/update_mixin_spec.rb
+++ b/spec/controllers/mixins/update_mixin_spec.rb
@@ -4,7 +4,7 @@ describe Api::Mixins::UpdateMixin do
     let(:tenant)      { Tenant.create! }
 
     it "patch /sources/:id updates a Source" do
-      source = Source.create!(:source_type => source_type, :tenant => tenant, :name => "abc")
+      source = Source.create!(:source_type => source_type, :tenant => tenant, :name => "abc", :uid => SecureRandom.uuid)
 
       patch(api_v0x0_source_url(source.id), :params => {:name => "xyz"})
 


### PR DESCRIPTION
https://github.com/ManageIQ/topological_inventory-core/pull/74 made the source uid mandatory so update the API specs accordingly.