### PR TITLE
Add the APP_NAME component of the path as a separate environment variable

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  prefix = ENV["PATH_PREFIX"] || "api"
+  prefix = "api"
+  prefix = "#{ENV["PATH_PREFIX"]}/#{ENV["APP_NAME"]}" if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
+
   scope :as => :api, :module => "api", :path => prefix do
     match "/v0/*path", :via => [:delete, :get, :options, :patch, :post, :put], :to => redirect("#{prefix}/v0.0/%{path}")
 

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -21,7 +21,7 @@ describe "Swagger stuff" do
 
     context "customizable route prefixes" do
       before do
-        stub_const("ENV", ENV.to_h.merge("PATH_PREFIX" => random_path))
+        stub_const("ENV", ENV.to_h.merge("PATH_PREFIX" => random_path, "APP_NAME" => random_path_part))
         Rails.application.reload_routes!
       end
 
@@ -31,7 +31,16 @@ describe "Swagger stuff" do
 
       it "with a random prefix" do
         expect(ENV["PATH_PREFIX"]).not_to be_nil
-        expect(api_v0x0_sources_url(:only_path => true)).to eq("/#{URI.encode(ENV["PATH_PREFIX"])}/v0.0/sources")
+        expect(ENV["APP_NAME"]).not_to be_nil
+        expect(api_v0x0_sources_url(:only_path => true)).to eq("/#{URI.encode(ENV["PATH_PREFIX"])}/#{URI.encode(ENV["APP_NAME"])}/v0.0/sources")
+      end
+
+      it "doesn't use the APP_NAME when PATH_PREFIX is empty" do
+        ENV["PATH_PREFIX"] = ""
+        Rails.application.reload_routes!
+
+        expect(ENV["APP_NAME"]).not_to be_nil
+        expect(api_v0x0_sources_url(:only_path => true)).to eq("/api/v0.0/sources")
       end
     end
 


### PR DESCRIPTION
We also only use the combined "PATH_PREFIX/APP_NAME" if both are
present. This allows us to continue to leave the PATH_PREFIX
value unset and get the default behavior yet still get the full
(production) behavior by setting it to "r/insights/platform"