### PR TITLE
Do not merge service plan order parameters to be used properly later

### DIFF
--- a/app/controllers/api/v0/service_plans_controller.rb
+++ b/app/controllers/api/v0/service_plans_controller.rb
@@ -6,17 +6,13 @@ module Api
 
       def order
         service_plan = model.find(service_plan_id)
-        task_id = service_plan.order(catalog_parameters)
+        task_id = service_plan.order(order_params)
         render :json => {:task_id => task_id}
       rescue ActiveRecord::RecordNotFound
         head :bad_request
       end
 
       private
-
-      def catalog_parameters
-        order_params[:service_parameters].merge(order_params[:provider_control_parameters])
-      end
 
       def service_plan_id
         params[:service_plan_id].to_i

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -23,12 +23,17 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
       ServiceOffering.create!(:source => source, :tenant => tenant, :source_region => source_region, :subscription => subscription)
     end
 
-    let(:catalog_parameters) { service_parameters.merge(provider_control_parameters) }
+    let(:order_parameters) do
+      {
+        :service_parameters          => service_parameters,
+        :provider_control_parameters => provider_control_parameters
+      }
+    end
     let(:service_parameters) { {"DB_NAME" => "TEST_DB", "namespace" => "TEST_DB_NAMESPACE"} }
     let(:provider_control_parameters) { {"namespace" => "test_project", "OpenShift_param1" => "test"} }
 
     before do
-      allow_any_instance_of(ServicePlan).to receive(:order).with(catalog_parameters).and_return("task_id")
+      allow_any_instance_of(ServicePlan).to receive(:order).with(order_parameters).and_return("task_id")
     end
 
     context "with a well formed service plan id" do


### PR DESCRIPTION
Instead of merging the `service_parameters` and `provider_control_parameters` into a single hash, we're just going to pass them through to the service plan and let it figure out what to do with them (as it needs certain things from each key).

This should be combined with [this core PR](https://github.com/ManageIQ/topological_inventory-core/pull/77).  It should be merged before the core PR, since if the other is merged first we will get actual runtime errors versus this getting merged first just causing external api errors. However since I don't think anyone is *actually* using this right this second, it probably doesn't really matter as long as they're both included in the same release.

@mkanoor @agrare 