### PR TITLE
Separate definition for order parameters

### DIFF
--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -455,18 +455,10 @@ paths:
       - $ref: '#/parameters/ID'
       - name: parameters
         in: body
-        description: Extra parameters defining the service and provider control
+        description: Order parameters defining the service and provider control
+        required: true
         schema:
-          type: object
-          properties:
-            service_parameters:
-              type: object
-              description: JSON object with provisioning parameters
-            provider_control_parameters:
-              type: object
-              description: >-
-                The provider specific parameters needed to provision this service.
-                This might include namespaces, special keys
+          $ref: '#/definitions/OrderParameters'
       responses:
         200:
           description: Returns a task ID for the order
@@ -1092,6 +1084,17 @@ definitions:
         type: string
         readOnly: true
         format: uuid
+  OrderParameters:
+    type: object
+    properties:
+      service_parameters:
+        type: object
+        description: JSON object with provisioning parameters
+      provider_control_parameters:
+        type: object
+        description: >-
+          The provider specific parameters needed to provision this service.
+          This might include namespaces, special keys
   ServiceInstance:
     type: object
     properties:

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -87,7 +87,7 @@ describe "Swagger stuff" do
     context "v0.0" do
       let(:version) { "0.0" }
       Api::Docs["0.0"].definitions.each do |definition_name, schema|
-        next if definition_name.in?(["Id"])
+        next if definition_name.in?(["Id", "OrderParameters"])
 
         it "#{definition_name} matches the JSONSchema" do
           const = definition_name.constantize


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/topological_inventory-api/issues/62

Use a separate definition for order parameters

This is only relevant for the client side, fixed the spec to ignore the OrderParameters during swagger definition validation.