### PR TITLE
Add missing Vms attributes

### DIFF
--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1564,6 +1564,31 @@ definitions:
         type: string
         readOnly: true
         format: uuid
+      uid_ems:
+        type: string
+        readOnly: true
+        description: Cross-Source Unique Reference
+      hostname:
+        type: string
+        readOnly: true
+        example: localhost.localdomain
+      power_state:
+        type: string
+        readOnly: true
+        example: running
+      cpus:
+        type: integer
+        readOnly: true
+        example: 2
+        description: Total number of CPUs
+      memory:
+        type: integer
+        readOnly: true
+        example: 17179869184
+        description: Total RAM in bytes
+      orchestration_stack_id:
+        type: "#/parameters/ID"
+        readOnly: true
       flavor_id:
         type: "#/parameters/ID"
         readOnly: true

--- a/spec/controllers/api/v0x0/vms_controller_spec.rb
+++ b/spec/controllers/api/v0x0/vms_controller_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe Api::V0x0::VmsController, :type => :request do
+  it("Uses IndexMixin") { expect(described_class.instance_method(:index).owner).to eq(Api::Mixins::IndexMixin) }
+  it("Uses ShowMixin")  { expect(described_class.instance_method(:show).owner).to eq(Api::Mixins::ShowMixin) }
+end


### PR DESCRIPTION
A number of VM attributes were added to core but not to the -api swagger.yaml

```
curl http://0.0.0.0:3000/api/v0.0/vms/1
{
  "id":1,
  "tenant_id":1,
  "source_id":1,
  "source_ref":"i-0b3fd3800910ced2f",
  "uid_ems":"i-0b3fd3800910ced2f",
  "name":"my-vm",
  "hostname":null,
  "description":null,
  "power_state":"on",
  "cpus":null,
  "memory":null,
  "extra":null,
  "resource_timestamp":null,
  "resource_timestamps":{},
  "resource_timestamps_max":null,
  "created_at":"2018-12-12T18:40:39.683Z",
  "updated_at":"2018-12-12T18:51:56.462Z",
  "archived_at":null,
  "source_created_at":null,
  "source_deleted_at":null,
  "orchestration_stack_id":null,
  "last_seen_at":"2018-12-12T18:51:56.475Z",
  "flavor_id":82
}
```