### PR TITLE
Workaround change to needs_migration? in rails 5.2

### DIFF
--- a/lib/tasks/deployment.rake
+++ b/lib/tasks/deployment.rake
@@ -1,7 +1,7 @@
 module ApplicationDeployment
   def self.status
     return "new_deployment" if ActiveRecord::Migrator.current_version.zero?
-    return "upgrade"        if ActiveRecord::Migrator.needs_migration?
+    return "upgrade"        if ActiveRecord::MigrationContext.new(ActiveRecord::Migrator.migrations_paths).needs_migration?
     "other"
   end
 end


### PR DESCRIPTION
In rails 5.2.0 there was a change to
ActiveRecord::Migrator.needs_migration? and it was moved under a
MigrationContext class.

Introduced by https://github.com/rails/rails/pull/31727