### PR TITLE
Fix issues with swagger definition and tests

### DIFF
--- a/lib/open_api/docs/doc_v2.rb
+++ b/lib/open_api/docs/doc_v2.rb
@@ -5,6 +5,7 @@ module OpenApi
 
       def initialize(content)
         @content = content
+        @expanded_definitions = {}
       end
 
       def version
@@ -20,8 +21,10 @@ module OpenApi
       end
 
       def expanded_definition(key)
-        definitions[key].tap do |i|
-          i["properties"] = substitute_references(i["properties"])
+        @expanded_definitions[key] ||= begin
+          definitions[key].tap do |i|
+            i["properties"] = substitute_references(i["properties"])
+          end
         end
       end
 

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -66,7 +66,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ContainerGroup info
@@ -285,7 +285,7 @@ paths:
         in: body
         required: true
         schema:
-          "$ref": "#/definitions/Id"
+          "$ref": "#/parameters/ID"
       responses:
         201:
           description: Endpoint info
@@ -618,7 +618,7 @@ paths:
         in: body
         required: true
         schema:
-          "$ref": "#/definitions/Id"
+          "$ref": "#/parameters/ID"
       responses:
         201:
           description: SourceType info
@@ -893,7 +893,7 @@ paths:
         in: body
         required: true
         schema:
-          "$ref": "#/definitions/Id"
+          "$ref": "#/parameters/ID"
       responses:
         201:
           description: Source info
@@ -1441,9 +1441,6 @@ definitions:
         readOnly: true
         example: 2
         description: Number of CPUs
-  Id:
-    type: string
-    format: uuid
   OrchestrationStack:
     type: object
     properties:

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -36,7 +36,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: Container info
@@ -89,7 +89,7 @@ paths:
             items:
               "$ref": "#/definitions/Container"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/container_images":
     get:
       summary: List ContainerImages
@@ -112,7 +112,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ContainerImage info
@@ -135,7 +135,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerGroup"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/container_nodes":
     get:
       summary: List ContainerNodes
@@ -158,7 +158,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ContainerNode info
@@ -181,7 +181,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerGroup"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/container_projects/{id}/container_templates":
     get:
       summary: List ContainerTemplates for ContainerProject
@@ -197,7 +197,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerTemplate"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/container_projects":
     get:
       summary: List ContainerProjects
@@ -220,7 +220,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ContainerProject info
@@ -250,7 +250,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ContainerTemplate info
@@ -301,7 +301,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: Endpoint info
@@ -318,7 +318,7 @@ paths:
       consumes:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         204:
           description: Updated, no content
@@ -333,7 +333,7 @@ paths:
       consumes:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         204:
           description: Updated, no content
@@ -346,7 +346,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         204:
           description: Endpoint deleted
@@ -374,7 +374,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: Flavor info
@@ -434,7 +434,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ServiceInstance info
@@ -457,7 +457,7 @@ paths:
             items:
               "$ref": "#/definitions/ServiceInstance"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/service_offerings/{id}/service_plans":
     get:
       summary: List ServicePlans for ServiceOffering
@@ -473,7 +473,7 @@ paths:
             items:
               "$ref": "#/definitions/ServicePlan"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/service_offerings":
     get:
       summary: List ServiceOfferings
@@ -496,7 +496,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ServiceOffering info
@@ -519,7 +519,7 @@ paths:
             items:
               "$ref": "#/definitions/ServiceInstance"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/service_plans":
     get:
       summary: List ServicePlans
@@ -542,7 +542,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: ServicePlan info
@@ -590,7 +590,7 @@ paths:
             items:
               "$ref": "#/definitions/Source"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/source_types":
     get:
       summary: List SourceTypes
@@ -634,7 +634,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: SourceType info
@@ -657,7 +657,7 @@ paths:
             items:
               "$ref": "#/definitions/Container"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/container_groups":
     get:
       summary: List ContainerGroups for Source
@@ -673,7 +673,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerGroup"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/container_images":
     get:
       summary: List ContainerImages for Source
@@ -689,7 +689,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerImage"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/container_nodes":
     get:
       summary: List ContainerNodes for Source
@@ -705,7 +705,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerNode"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/container_projects":
     get:
       summary: List ContainerProjects for Source
@@ -721,7 +721,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerProject"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/container_templates":
     get:
       summary: List ContainerTemplates for Source
@@ -737,7 +737,7 @@ paths:
             items:
               "$ref": "#/definitions/ContainerTemplate"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/endpoints":
     get:
       summary: List Endpoints for Source
@@ -753,7 +753,7 @@ paths:
             items:
               "$ref": "#/definitions/Endpoint"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/orchestration_stacks":
     get:
       summary: List OrchestrationStacks for Source
@@ -769,7 +769,7 @@ paths:
             items:
               "$ref": "#/definitions/OrchestrationStack"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/service_instances":
     get:
       summary: List ServiceInstances for Source
@@ -785,7 +785,7 @@ paths:
             items:
               "$ref": "#/definitions/ServiceInstance"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/service_offerings":
     get:
       summary: List ServiceOfferings for Source
@@ -801,7 +801,7 @@ paths:
             items:
               "$ref": "#/definitions/ServiceOffering"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/service_plans":
     get:
       summary: List ServicePlans for Source
@@ -817,7 +817,7 @@ paths:
             items:
               "$ref": "#/definitions/ServicePlan"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/vms":
     get:
       summary: List Vms for Source
@@ -833,7 +833,7 @@ paths:
             items:
               "$ref": "#/definitions/Vm"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/volume_types":
     get:
       summary: List VolumeTypes for Source
@@ -849,7 +849,7 @@ paths:
             items:
               "$ref": "#/definitions/VolumeType"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources/{id}/volumes":
     get:
       summary: List Volumes for Source
@@ -865,7 +865,7 @@ paths:
             items:
               "$ref": "#/definitions/Volume"
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
   "/sources":
     get:
       summary: List Sources
@@ -909,7 +909,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: Source info
@@ -926,7 +926,7 @@ paths:
       consumes:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         204:
           description: Updated, no content
@@ -941,7 +941,7 @@ paths:
       consumes:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         204:
           description: Updated, no content
@@ -954,7 +954,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         204:
           description: Source deleted
@@ -982,7 +982,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: Task info
@@ -1012,7 +1012,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: Vm info
@@ -1074,7 +1074,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: VolumeAttachment info
@@ -1104,7 +1104,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: VolumeType info
@@ -1134,7 +1134,7 @@ paths:
       produces:
       - application/json
       parameters:
-        - $ref: '#/parameters/ID'
+      - "$ref": "#/parameters/ID"
       responses:
         200:
           description: Volume info

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1155,11 +1155,13 @@ definitions:
     type: object
     properties:
       id:
-        type: "#/parameters/id"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       tenant_id:
-        type: "#/parameters/id"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       name:
         type: string
         readOnly: true
@@ -1179,11 +1181,13 @@ definitions:
         type: integer
         readOnly: true
       container_group_id:
-        type: "#/parameters/id"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       container_image_id:
-        type: "#/parameters/id"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
   ContainerGroup:
     type: object
     properties:
@@ -1233,14 +1237,17 @@ definitions:
     type: object
     properties:
       id:
-        type: "#/parameters/id"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       tenant_id:
-        type: "#/parameters/id"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_id:
-        type: "#/parameters/id"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       name:
         type: string
         readOnly: true
@@ -1409,14 +1416,17 @@ definitions:
     type: object
     properties:
       id:
-        type: "#/parameters/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       tenant_id:
-        type: "#/parameters/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_id:
-        type: "#/parameters/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_ref:
         type: string
         readOnly: true
@@ -1748,29 +1758,36 @@ definitions:
         example: 17179869184
         description: Total RAM in bytes
       orchestration_stack_id:
-        type: "#/parameters/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       flavor_id:
-        type: "#/parameters/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
   Volume:
     type: object
     properties:
       id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       tenant_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_region_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       volume_type_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_ref:
         type: string
         readOnly: true
@@ -1796,17 +1813,21 @@ definitions:
     type: object
     properties:
       id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       tenant_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       vm_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       volume_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       device:
         type: string
         readOnly: true
@@ -1819,14 +1840,17 @@ definitions:
     type: object
     properties:
       id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       tenant_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_id:
-        type: "#/properties/ID"
-        readOnly: true
+        allOf:
+        - "$ref": "#/parameters/ID"
+        - readOnly: true
       source_ref:
         type: string
       name:

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -14,36 +14,6 @@ securityDefinitions:
 security:
 - UserSecurity: []
 paths:
-  "/containers":
-    get:
-      summary: List Containers
-      operationId: listContainers
-      description: Returns an array of Container objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: Containers array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/Container"
-  "/containers/{id}":
-    get:
-      summary: Show an existing Container
-      operationId: showContainer
-      description: Returns a Container object
-      produces:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        200:
-          description: Container info
-          schema:
-            "$ref": "#/definitions/Container"
-        404:
-          description: Not found
   "/container_groups":
     get:
       summary: List ContainerGroups
@@ -120,22 +90,6 @@ paths:
             "$ref": "#/definitions/ContainerImage"
         404:
           description: Not found
-  "/container_nodes/{id}/container_groups":
-    get:
-      summary: List ContainerGroups for ContainerNode
-      operationId: listContainerNodeContainerGroups
-      description: Returns an array of ContainerGroup objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: ContainerGroups array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/ContainerGroup"
-      parameters:
-      - "$ref": "#/parameters/ID"
   "/container_nodes":
     get:
       summary: List ContainerNodes
@@ -164,6 +118,52 @@ paths:
           description: ContainerNode info
           schema:
             "$ref": "#/definitions/ContainerNode"
+        404:
+          description: Not found
+  "/container_nodes/{id}/container_groups":
+    get:
+      summary: List ContainerGroups for ContainerNode
+      operationId: listContainerNodeContainerGroups
+      description: Returns an array of ContainerGroup objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: ContainerGroups array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/ContainerGroup"
+      parameters:
+      - "$ref": "#/parameters/ID"
+  "/container_projects":
+    get:
+      summary: List ContainerProjects
+      operationId: listContainerProjects
+      description: Returns an array of ContainerProject objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: ContainerProjects array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/ContainerProject"
+  "/container_projects/{id}":
+    get:
+      summary: Show an existing ContainerProject
+      operationId: showContainerProject
+      description: Returns a ContainerProject object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: ContainerProject info
+          schema:
+            "$ref": "#/definitions/ContainerProject"
         404:
           description: Not found
   "/container_projects/{id}/container_groups":
@@ -198,36 +198,6 @@ paths:
               "$ref": "#/definitions/ContainerTemplate"
       parameters:
       - "$ref": "#/parameters/ID"
-  "/container_projects":
-    get:
-      summary: List ContainerProjects
-      operationId: listContainerProjects
-      description: Returns an array of ContainerProject objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: ContainerProjects array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/ContainerProject"
-  "/container_projects/{id}":
-    get:
-      summary: Show an existing ContainerProject
-      operationId: showContainerProject
-      description: Returns a ContainerProject object
-      produces:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        200:
-          description: ContainerProject info
-          schema:
-            "$ref": "#/definitions/ContainerProject"
-        404:
-          description: Not found
   "/container_templates":
     get:
       summary: List ContainerTemplates
@@ -256,6 +226,36 @@ paths:
           description: ContainerTemplate info
           schema:
             "$ref": "#/definitions/ContainerTemplate"
+        404:
+          description: Not found
+  "/containers":
+    get:
+      summary: List Containers
+      operationId: listContainers
+      description: Returns an array of Container objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Containers array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Container"
+  "/containers/{id}":
+    get:
+      summary: Show an existing Container
+      operationId: showContainer
+      description: Returns a Container object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: Container info
+          schema:
+            "$ref": "#/definitions/Container"
         404:
           description: Not found
   "/endpoints":
@@ -382,6 +382,36 @@ paths:
             "$ref": "#/definitions/Flavor"
         404:
           description: Not found
+  "/orchestration_stacks":
+    get:
+      summary: List OrchestrationStacks
+      operationId: listOrchestrationStacks
+      description: Returns an array of OrchestrationStack objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: OrchestrationStacks array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/OrchestrationStack"
+  "/orchestration_stacks/{id}":
+    get:
+      summary: Show an existing OrchestrationStack
+      operationId: showOrchestrationStack
+      description: Returns a OrchestrationStack object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: OrchestrationStack info
+          schema:
+            "$ref": "#/definitions/OrchestrationStack"
+        404:
+          description: Not found
   "/service_instances":
     get:
       summary: List ServiceInstances
@@ -410,6 +440,36 @@ paths:
           description: ServiceInstance info
           schema:
             "$ref": "#/definitions/ServiceInstance"
+        404:
+          description: Not found
+  "/service_offerings":
+    get:
+      summary: List ServiceOfferings
+      operationId: listServiceOfferings
+      description: Returns an array of ServiceOffering objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: ServiceOfferings array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/ServiceOffering"
+  "/service_offerings/{id}":
+    get:
+      summary: Show an existing ServiceOffering
+      operationId: showServiceOffering
+      description: Returns a ServiceOffering object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: ServiceOffering info
+          schema:
+            "$ref": "#/definitions/ServiceOffering"
         404:
           description: Not found
   "/service_offerings/{id}/service_instances":
@@ -444,107 +504,6 @@ paths:
               "$ref": "#/definitions/ServicePlan"
       parameters:
       - "$ref": "#/parameters/ID"
-  "/service_offerings":
-    get:
-      summary: List ServiceOfferings
-      operationId: listServiceOfferings
-      description: Returns an array of ServiceOffering objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: ServiceOfferings array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/ServiceOffering"
-  "/service_offerings/{id}":
-    get:
-      summary: Show an existing ServiceOffering
-      operationId: showServiceOffering
-      description: Returns a ServiceOffering object
-      produces:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        200:
-          description: ServiceOffering info
-          schema:
-            "$ref": "#/definitions/ServiceOffering"
-        404:
-          description: Not found
-  "/orchestration_stacks":
-    get:
-      summary: List OrchestrationStacks
-      operationId: listOrchestrationStacks
-      description: Returns an array of OrchestrationStack objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: OrchestrationStacks array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/OrchestrationStack"
-  "/orchestration_stacks/{id}":
-    get:
-      summary: Show an existing OrchestrationStack
-      operationId: showOrchestrationStack
-      description: Returns a OrchestrationStack object
-      produces:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        200:
-          description: OrchestrationStack info
-          schema:
-            "$ref": "#/definitions/OrchestrationStack"
-        404:
-          description: Not found
-  "/service_plans/{id}/order":
-    post:
-      summary: Order an existing ServicePlan
-      operationId: orderServicePlan
-      description: Returns a Task id
-      consumes:
-      - application/json
-      parameters:
-      - $ref: '#/parameters/ID'
-      - name: parameters
-        in: body
-        description: Order parameters defining the service and provider control
-        required: true
-        schema:
-          $ref: '#/definitions/OrderParameters'
-      responses:
-        200:
-          description: Returns a task ID for the order
-          schema:
-            type: object
-            properties:
-              task_id:
-                type: string
-        400:
-          description: BadRequest
-  "/service_plans/{id}/service_instances":
-    get:
-      summary: List ServiceInstances for ServicePlan
-      operationId: listServicePlanServiceInstances
-      description: Returns an array of ServiceInstance objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: ServiceInstances array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/ServiceInstance"
-      parameters:
-      - "$ref": "#/parameters/ID"
   "/service_plans":
     get:
       summary: List ServicePlans
@@ -575,20 +534,45 @@ paths:
             "$ref": "#/definitions/ServicePlan"
         404:
           description: Not found
-  "/source_types/{id}/sources":
+  "/service_plans/{id}/order":
+    post:
+      summary: Order an existing ServicePlan
+      operationId: orderServicePlan
+      description: Returns a Task id
+      consumes:
+      - application/json
+      parameters:
+      - "$ref": '#/parameters/ID'
+      - name: parameters
+        in: body
+        description: Order parameters defining the service and provider control
+        required: true
+        schema:
+          $ref: '#/definitions/OrderParameters'
+      responses:
+        200:
+          description: Returns a task ID for the order
+          schema:
+            type: object
+            properties:
+              task_id:
+                type: string
+        400:
+          description: BadRequest
+  "/service_plans/{id}/service_instances":
     get:
-      summary: List Sources for SourceType
-      operationId: listSourceTypeSources
-      description: Returns an array of Source objects
+      summary: List ServiceInstances for ServicePlan
+      operationId: listServicePlanServiceInstances
+      description: Returns an array of ServiceInstance objects
       produces:
       - application/json
       responses:
         200:
-          description: Sources array
+          description: ServiceInstances array
           schema:
             type: array
             items:
-              "$ref": "#/definitions/Source"
+              "$ref": "#/definitions/ServiceInstance"
       parameters:
       - "$ref": "#/parameters/ID"
   "/source_types":
@@ -642,22 +626,116 @@ paths:
             "$ref": "#/definitions/SourceType"
         404:
           description: Not found
-  "/sources/{id}/containers":
+  "/source_types/{id}/sources":
     get:
-      summary: List Containers for Source
-      operationId: listSourceContainers
-      description: Returns an array of Container objects
+      summary: List Sources for SourceType
+      operationId: listSourceTypeSources
+      description: Returns an array of Source objects
       produces:
       - application/json
       responses:
         200:
-          description: Containers array
+          description: Sources array
           schema:
             type: array
             items:
-              "$ref": "#/definitions/Container"
+              "$ref": "#/definitions/Source"
       parameters:
       - "$ref": "#/parameters/ID"
+  "/sources":
+    get:
+      summary: List Sources
+      operationId: listSources
+      description: Returns an array of Source objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Sources array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Source"
+    post:
+      summary: Create a new Source
+      operationId: createSource
+      description: Creates a Source object
+      produces:
+      - application/json
+      consumes:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          "$ref": "#/parameters/ID"
+      responses:
+        201:
+          description: Source info
+          schema:
+            type: object
+            items:
+              "$ref": "#/definitions/Source"
+  "/sources/{id}":
+    get:
+      summary: Show an existing Source
+      operationId: showSource
+      description: Returns a Source object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: Source info
+          schema:
+            "$ref": "#/definitions/Source"
+        404:
+          description: Not found
+    patch:
+      summary: Update an existing Source
+      operationId: updateSource
+      description: Updates a Source object
+      produces:
+      - application/json
+      consumes:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        204:
+          description: Updated, no content
+        404:
+          description: Not found
+    put:
+      summary: Replace an existing Source
+      operationId: replaceSource
+      description: Replaces a Source object
+      produces:
+      - application/json
+      consumes:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        204:
+          description: Updated, no content
+        404:
+          description: Not found
+    delete:
+      summary: Delete an existing Source
+      operationId: deleteSource
+      description: Deletes a Source object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        204:
+          description: Source deleted
+        404:
+          description: Not found
   "/sources/{id}/container_groups":
     get:
       summary: List ContainerGroups for Source
@@ -736,6 +814,22 @@ paths:
             type: array
             items:
               "$ref": "#/definitions/ContainerTemplate"
+      parameters:
+      - "$ref": "#/parameters/ID"
+  "/sources/{id}/containers":
+    get:
+      summary: List Containers for Source
+      operationId: listSourceContainers
+      description: Returns an array of Container objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Containers array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Container"
       parameters:
       - "$ref": "#/parameters/ID"
   "/sources/{id}/endpoints":
@@ -866,100 +960,6 @@ paths:
               "$ref": "#/definitions/Volume"
       parameters:
       - "$ref": "#/parameters/ID"
-  "/sources":
-    get:
-      summary: List Sources
-      operationId: listSources
-      description: Returns an array of Source objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: Sources array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/Source"
-    post:
-      summary: Create a new Source
-      operationId: createSource
-      description: Creates a Source object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - name: body
-        in: body
-        required: true
-        schema:
-          "$ref": "#/parameters/ID"
-      responses:
-        201:
-          description: Source info
-          schema:
-            type: object
-            items:
-              "$ref": "#/definitions/Source"
-  "/sources/{id}":
-    get:
-      summary: Show an existing Source
-      operationId: showSource
-      description: Returns a Source object
-      produces:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        200:
-          description: Source info
-          schema:
-            "$ref": "#/definitions/Source"
-        404:
-          description: Not found
-    patch:
-      summary: Update an existing Source
-      operationId: updateSource
-      description: Updates a Source object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
-    put:
-      summary: Replace an existing Source
-      operationId: replaceSource
-      description: Replaces a Source object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
-    delete:
-      summary: Delete an existing Source
-      operationId: deleteSource
-      description: Deletes a Source object
-      produces:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        204:
-          description: Source deleted
-        404:
-          description: Not found
   "/tasks":
     get:
       summary: List Tasks
@@ -988,6 +988,36 @@ paths:
           description: Task info
           schema:
             "$ref": "#/definitions/Task"
+        404:
+          description: Not found
+  "/vms":
+    get:
+      summary: List Vms
+      operationId: listVms
+      description: Returns an array of Vm objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Vms array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Vm"
+  "/vms/{id}":
+    get:
+      summary: Show an existing Vm
+      operationId: showVm
+      description: Returns a Vm object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: Vm info
+          schema:
+            "$ref": "#/definitions/Vm"
         404:
           description: Not found
   "/vms/{id}/volume_attachments":
@@ -1022,36 +1052,6 @@ paths:
               "$ref": "#/definitions/Volume"
       parameters:
       - "$ref": "#/parameters/ID"
-  "/vms":
-    get:
-      summary: List Vms
-      operationId: listVms
-      description: Returns an array of Vm objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: Vms array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/Vm"
-  "/vms/{id}":
-    get:
-      summary: Show an existing Vm
-      operationId: showVm
-      description: Returns a Vm object
-      produces:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      responses:
-        200:
-          description: Vm info
-          schema:
-            "$ref": "#/definitions/Vm"
-        404:
-          description: Not found
   "/volume_attachments":
     get:
       summary: List VolumeAttachments

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1156,34 +1156,34 @@ definitions:
     properties:
       id:
         type: "#/parameters/id"
-        readonly: true
+        readOnly: true
       tenant_id:
         type: "#/parameters/id"
-        readonly: true
+        readOnly: true
       name:
         type: string
-        readonly: true
+        readOnly: true
         example: docker-build
       cpu_limit:
         type: number
         format: double
-        readonly: true
+        readOnly: true
       cpu_request:
         type: number
         format: double
-        readonly: true
+        readOnly: true
       memory_limit:
         type: integer
-        readonly: true
+        readOnly: true
       memory_request:
         type: integer
-        readonly: true
+        readOnly: true
       container_group_id:
         type: "#/parameters/id"
-        readonly: true
+        readOnly: true
       container_image_id:
         type: "#/parameters/id"
-        readonly: true
+        readOnly: true
   ContainerGroup:
     type: object
     properties:
@@ -1234,16 +1234,16 @@ definitions:
     properties:
       id:
         type: "#/parameters/id"
-        readonly: true
+        readOnly: true
       tenant_id:
         type: "#/parameters/id"
-        readonly: true
+        readOnly: true
       source_id:
         type: "#/parameters/id"
-        readonly: true
+        readOnly: true
       name:
         type: string
-        readonly: true
+        readOnly: true
         example: openshift3/postgresql-92-rhel7
       tag:
         type: string

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1758,13 +1758,13 @@ definitions:
         example: 17179869184
         description: Total RAM in bytes
       orchestration_stack_id:
-        allOf:
-        - "$ref": "#/parameters/ID"
-        - readOnly: true
+        type: string
+        readOnly: true
+        format: uuid
       flavor_id:
-        allOf:
-        - "$ref": "#/parameters/ID"
-        - readOnly: true
+        type: string
+        readOnly: true
+        format: uuid
   Volume:
     type: object
     properties:
@@ -1781,9 +1781,9 @@ definitions:
         - "$ref": "#/parameters/ID"
         - readOnly: true
       source_region_id:
-        allOf:
-        - "$ref": "#/parameters/ID"
-        - readOnly: true
+        type: string
+        readOnly: true
+        format: uuid
       volume_type_id:
         allOf:
         - "$ref": "#/parameters/ID"

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1149,7 +1149,7 @@ parameters:
     description: ID of the resource
     required: true
     type: string
-    pattern: '/^\d+$/'
+    pattern: "/^\\d+$/"
 definitions:
   Container:
     type: object

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1229,6 +1229,34 @@ definitions:
         type: string
         readOnly: true
         format: uuid
+  ContainerImage:
+    type: object
+    properties:
+      id:
+        type: "#/parameters/id"
+        readonly: true
+      tenant_id:
+        type: "#/parameters/id"
+        readonly: true
+      source_id:
+        type: "#/parameters/id"
+        readonly: true
+      name:
+        type: string
+        readonly: true
+        example: openshift3/postgresql-92-rhel7
+      tag:
+        type: string
+        readOnly: true
+        example: latest
+      source_created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      source_deleted_at:
+        type: string
+        format: date-time
+        readOnly: true
   ContainerNode:
     type: object
     properties:
@@ -1276,34 +1304,6 @@ definitions:
         type: string
         readOnly: true
         format: uuid
-  ContainerImage:
-    type: object
-    properties:
-      id:
-        type: "#/parameters/id"
-        readonly: true
-      tenant_id:
-        type: "#/parameters/id"
-        readonly: true
-      source_id:
-        type: "#/parameters/id"
-        readonly: true
-      name:
-        type: string
-        readonly: true
-        example: openshift3/postgresql-92-rhel7
-      tag:
-        type: string
-        readOnly: true
-        example: latest
-      source_created_at:
-        type: string
-        format: date-time
-        readOnly: true
-      source_deleted_at:
-        type: string
-        format: date-time
-        readOnly: true
   ContainerProject:
     type: object
     properties:
@@ -1756,49 +1756,6 @@ definitions:
       flavor_id:
         type: "#/parameters/ID"
         readOnly: true
-  VolumeAttachment:
-    type: object
-    properties:
-      id:
-        type: "#/properties/ID"
-        readOnly: true
-      tenant_id:
-        type: "#/properties/ID"
-        readOnly: true
-      vm_id:
-        type: "#/properties/ID"
-        readOnly: true
-      volume_id:
-        type: "#/properties/ID"
-        readOnly: true
-      device:
-        type: string
-        readOnly: true
-        example: /dev/xvda
-      state:
-        type: string
-        readOnly: true
-        example: attached
-  VolumeType:
-    type: object
-    properties:
-      id:
-        type: "#/properties/ID"
-        readOnly: true
-      tenant_id:
-        type: "#/properties/ID"
-        readOnly: true
-      source_id:
-        type: "#/properties/ID"
-        readOnly: true
-      source_ref:
-        type: string
-      name:
-        type: string
-        example: standard
-      description:
-        type: string
-        example: Magnetic
   Volume:
     type: object
     properties:
@@ -1838,6 +1795,49 @@ definitions:
         type: string
         format: date-time
         readOnly: true
+  VolumeAttachment:
+    type: object
+    properties:
+      id:
+        type: "#/properties/ID"
+        readOnly: true
+      tenant_id:
+        type: "#/properties/ID"
+        readOnly: true
+      vm_id:
+        type: "#/properties/ID"
+        readOnly: true
+      volume_id:
+        type: "#/properties/ID"
+        readOnly: true
+      device:
+        type: string
+        readOnly: true
+        example: "/dev/xvda"
+      state:
+        type: string
+        readOnly: true
+        example: attached
+  VolumeType:
+    type: object
+    properties:
+      id:
+        type: "#/properties/ID"
+        readOnly: true
+      tenant_id:
+        type: "#/properties/ID"
+        readOnly: true
+      source_id:
+        type: "#/properties/ID"
+        readOnly: true
+      source_ref:
+        type: string
+      name:
+        type: string
+        example: standard
+      description:
+        type: string
+        example: Magnetic
 host: virtserver.swaggerhub.com
 schemes:
 - https

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -382,36 +382,6 @@ paths:
             "$ref": "#/definitions/Flavor"
         404:
           description: Not found
-  "/orchestration_stacks":
-    get:
-      summary: List OrchestrationStacks
-      operationId: listOrchestrationStacks
-      description: Returns an array of OrchestrationStack objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: OrchestrationStacks array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/OrchestrationStack"
-  "/orchestration_stacks/{id}":
-    get:
-      summary: Show an existing OrchestrationStack
-      operationId: showOrchestrationStack
-      description: Returns an OrchestrationStack object
-      produces:
-      - application/json
-      parameters:
-        - $ref: '#/parameters/ID'
-      responses:
-        200:
-          description: OrchestrationStack info
-          schema:
-            "$ref": "#/definitions/OrchestrationStack"
-        404:
-          description: Not found
   "/service_instances":
     get:
       summary: List ServiceInstances
@@ -504,6 +474,61 @@ paths:
             "$ref": "#/definitions/ServiceOffering"
         404:
           description: Not found
+  "/orchestration_stacks":
+    get:
+      summary: List OrchestrationStacks
+      operationId: listOrchestrationStacks
+      description: Returns an array of OrchestrationStack objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: OrchestrationStacks array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/OrchestrationStack"
+  "/orchestration_stacks/{id}":
+    get:
+      summary: Show an existing OrchestrationStack
+      operationId: showOrchestrationStack
+      description: Returns a OrchestrationStack object
+      produces:
+      - application/json
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: OrchestrationStack info
+          schema:
+            "$ref": "#/definitions/OrchestrationStack"
+        404:
+          description: Not found
+  "/service_plans/{id}/order":
+    post:
+      summary: Order an existing ServicePlan
+      operationId: orderServicePlan
+      description: Returns a Task id
+      consumes:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: parameters
+        in: body
+        description: Order parameters defining the service and provider control
+        required: true
+        schema:
+          $ref: '#/definitions/OrderParameters'
+      responses:
+        200:
+          description: Returns a task ID for the order
+          schema:
+            type: object
+            properties:
+              task_id:
+                type: string
+        400:
+          description: BadRequest
   "/service_plans/{id}/service_instances":
     get:
       summary: List ServiceInstances for ServicePlan
@@ -550,31 +575,6 @@ paths:
             "$ref": "#/definitions/ServicePlan"
         404:
           description: Not found
-  "/service_plans/{id}/order":
-    post:
-      summary: Order an existing ServicePlan
-      operationId: orderServicePlan
-      description: Returns a Task id
-      consumes:
-      - application/json
-      parameters:
-      - $ref: '#/parameters/ID'
-      - name: parameters
-        in: body
-        description: Order parameters defining the service and provider control
-        required: true
-        schema:
-          $ref: '#/definitions/OrderParameters'
-      responses:
-        200:
-          description: Returns a task ID for the order
-          schema:
-            type: object
-            properties:
-              task_id:
-                type: string
-        400:
-          description: BadRequest
   "/source_types/{id}/sources":
     get:
       summary: List Sources for SourceType
@@ -990,6 +990,38 @@ paths:
             "$ref": "#/definitions/Task"
         404:
           description: Not found
+  "/vms/{id}/volume_attachments":
+    get:
+      summary: List VolumeAttachments for Vm
+      operationId: listVmVolumeAttachments
+      description: Returns an array of VolumeAttachment objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: VolumeAttachments array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/VolumeAttachment"
+      parameters:
+      - "$ref": "#/parameters/ID"
+  "/vms/{id}/volumes":
+    get:
+      summary: List Volumes for Vm
+      operationId: listVmVolumes
+      description: Returns an array of Volume objects
+      produces:
+      - application/json
+      responses:
+        200:
+          description: Volumes array
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Volume"
+      parameters:
+      - "$ref": "#/parameters/ID"
   "/vms":
     get:
       summary: List Vms
@@ -1020,38 +1052,6 @@ paths:
             "$ref": "#/definitions/Vm"
         404:
           description: Not found
-  "/vms/{id}/volume_attachments":
-    get:
-      summary: List VolumeAttachments for a Vm
-      operationId: listVmVolumeAttachments
-      description: Returns an array of VolumeAttachment objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: VolumeAttachments array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/VolumeAttachment"
-      parameters:
-        - $ref: '#/parameters/ID'
-  "/vms/{id}/volumes":
-    get:
-      summary: List Volumes for a Vm
-      operationId: listVmVolumes
-      description: Returns an array of Volume objects
-      produces:
-      - application/json
-      responses:
-        200:
-          description: Volumes array
-          schema:
-            type: array
-            items:
-              "$ref": "#/definitions/Volume"
-      parameters:
-        - $ref: '#/parameters/ID'
   "/volume_attachments":
     get:
       summary: List VolumeAttachments

--- a/spec/support/json_schema_matcher.rb
+++ b/spec/support/json_schema_matcher.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :match_json_schema do |version, schema|
   match do |parsed_body|
-    s = Api::Docs[version].definitions[schema]
+    s = Api::Docs[version].expanded_definition(schema)
     JSON::Validator.validate!(s, parsed_body)
   end
 end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -101,7 +101,7 @@ describe "Swagger stuff" do
     context "v0.0" do
       let(:version) { "0.0" }
       Api::Docs["0.0"].definitions.each do |definition_name, schema|
-        next if definition_name.in?(["Id", "OrderParameters"])
+        next if definition_name.in?(["OrderParameters"])
 
         it "#{definition_name} matches the JSONSchema" do
           const = definition_name.constantize


### PR DESCRIPTION
- Alphabetize paths and definitions for readability
- Fix whitespace
- Properly escape regex
- Fix quoting issues
- Fix typo `readonly` to `readOnly`
- Describing an attribute / parameter with `$ref` and local definitions needs to be wrapped in `allOf:`
- Load swagger regexes as real regexes for validation purposes
- Revert changes to optional _id attributes
- Fix unknown reference issues during validation in rspec matcher