### PR TITLE
Add schema to params for SourceTypes.

### DIFF
--- a/app/controllers/api/v0/source_types_controller.rb
+++ b/app/controllers/api/v0/source_types_controller.rb
@@ -12,7 +12,7 @@ module Api
       private
 
       def create_params
-        body_params.permit(:name, :product_name, :vendor)
+        body_params.permit(:name, :product_name, :vendor, :schema)
       end
 
       def list_params

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1655,6 +1655,8 @@ definitions:
       vendor:
         type: string
         example: Red Hat
+      schema:
+        type: object
   Task:
     type: object
     properties:


### PR DESCRIPTION
@agrare, @bdunne  : Do I need this to be able to access the `:schema` via the API?