### PR TITLE
Remove unicode coloring from container logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module TopologicalInventory
 
     require 'manageiq/loggers'
     config.logger = if Rails.env.production?
+                      config.colorize_logging = false
                       ManageIQ::Loggers::Container.new
                     else
                       ManageIQ::Loggers::Base.new(Rails.root.join("log", "#{Rails.env}.log"))


### PR DESCRIPTION
Before:
`"message":"  \u001b[1m\u001b[36mSource Load (0.5ms)\u001b[0m  \u001b[1m\u001b[34mSELECT \"sources\".* FROM \"sources\"\u001b[0m"`

After:
`"message":"  Source Load (0.4ms)  SELECT \"sources\".* FROM \"sources\""`