### PR TITLE
Add some basic prometheus metrics at the /metrics endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'json-schema',       '~> 2.8'
 gem 'manageiq-loggers',  '~> 0.1'
 gem 'manageiq-password', '~> 0.1'
 gem 'pg',                '~> 1.0', :require => false
+gem 'prometheus-client', '~> 0.8.0'
 gem 'puma',              '~> 3.0'
 gem 'rack-cors',         '>= 0.4.1'
 gem 'rails',             '~> 5.2.1.1'

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
 module TopologicalInventory
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -35,5 +38,8 @@ module TopologicalInventory
                     else
                       ManageIQ::Loggers::Base.new(Rails.root.join("log", "#{Rails.env}.log"))
                     end
+
+    config.middleware.use(Prometheus::Middleware::Collector)
+    config.middleware.use(Prometheus::Middleware::Exporter)
   end
 end


### PR DESCRIPTION
This should be a good first pass on
https://projects.engineering.redhat.com/browse/TPINVTRY-142

I imagine that this is a good candidate for the api-common engine/gem/thing but I'm really opening this just as a place to figure out how we want to do this.

This gives me a basic metrics page that describes the requests served and timings.

![image](https://user-images.githubusercontent.com/12697904/51059336-d4830480-15b9-11e9-953a-bc5d83740df1.png)
