### PR TITLE
Disable HTTP PUT

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,14 @@
 Rails.application.routes.draw do
+  # Disable PUT for now since rails sends these :update and they aren't really the same thing.
+  def put(*_args); end
+
   prefix = "api"
   if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
     prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
   end
 
   scope :as => :api, :module => "api", :path => prefix do
-    match "/v0/*path", :via => [:delete, :get, :options, :patch, :post, :put], :to => redirect("#{prefix}/v0.0/%{path}")
+    match "/v0/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect("#{prefix}/v0.0/%{path}")
 
     namespace :v0x1, :path => "v0.1" do
       resources :authentications,         :only => [:create, :destroy, :index, :show, :update]

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -87,27 +87,6 @@ paths:
           description: Updated, no content
         404:
           description: Not found
-    put:
-      summary: Replace an existing Authentication
-      operationId: replaceAuthentication
-      description: Replaces a Authentication object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      - name: body
-        in: body
-        description: Authentication attributes to update
-        required: true
-        schema:
-          "$ref": "#/definitions/Authentication"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
     delete:
       summary: Delete an existing Authentication
       operationId: deleteAuthentication
@@ -421,27 +400,6 @@ paths:
       summary: Update an existing Endpoint
       operationId: updateEndpoint
       description: Updates a Endpoint object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      - name: body
-        in: body
-        description: Endpoint attributes to update
-        required: true
-        schema:
-          "$ref": "#/definitions/Endpoint"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
-    put:
-      summary: Replace an existing Endpoint
-      operationId: replaceEndpoint
-      description: Replaces a Endpoint object
       produces:
       - application/json
       consumes:
@@ -819,27 +777,6 @@ paths:
       summary: Update an existing Source
       operationId: updateSource
       description: Updates a Source object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      - name: body
-        in: body
-        description: Source attributes to update
-        required: true
-        schema:
-          "$ref": "#/definitions/Source"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
-    put:
-      summary: Replace an existing Source
-      operationId: replaceSource
-      description: Replaces a Source object
       produces:
       - application/json
       consumes:

--- a/public/doc/swagger-2-v0.1.0.yaml
+++ b/public/doc/swagger-2-v0.1.0.yaml
@@ -88,27 +88,6 @@ paths:
           description: Updated, no content
         404:
           description: Not found
-    put:
-      summary: Replace an existing Authentication
-      operationId: replaceAuthentication
-      description: Replaces a Authentication object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      - name: body
-        in: body
-        description: Authentication attributes to update
-        required: true
-        schema:
-          "$ref": "#/definitions/Authentication"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
     delete:
       summary: Delete an existing Authentication
       operationId: deleteAuthentication
@@ -429,27 +408,6 @@ paths:
       summary: Update an existing Endpoint
       operationId: updateEndpoint
       description: Updates a Endpoint object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      - name: body
-        in: body
-        description: Endpoint attributes to update
-        required: true
-        schema:
-          "$ref": "#/definitions/Endpoint"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
-    put:
-      summary: Replace an existing Endpoint
-      operationId: replaceEndpoint
-      description: Replaces a Endpoint object
       produces:
       - application/json
       consumes:
@@ -834,27 +792,6 @@ paths:
       summary: Update an existing Source
       operationId: updateSource
       description: Updates a Source object
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - "$ref": "#/parameters/ID"
-      - name: body
-        in: body
-        description: Source attributes to update
-        required: true
-        schema:
-          "$ref": "#/definitions/Source"
-      responses:
-        204:
-          description: Updated, no content
-        404:
-          description: Not found
-    put:
-      summary: Replace an existing Source
-      operationId: replaceSource
-      description: Replaces a Source object
       produces:
       - application/json
       consumes:

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -28,7 +28,7 @@ describe "Swagger stuff" do
       let(:path_prefix) { "/r/insights/platform" }
 
       it "matches the routes" do
-        redirect_routes = [{:path => "#{path_prefix}/#{app_name}/v0/*path", :verb => "DELETE|GET|OPTIONS|PATCH|POST|PUT"}]
+        redirect_routes = [{:path => "#{path_prefix}/#{app_name}/v0/*path", :verb => "DELETE|GET|OPTIONS|PATCH|POST"}]
         expect(rails_routes).to match_array(swagger_routes + redirect_routes)
       end
     end


### PR DESCRIPTION
Rails sends PUT and PATCH to :update, they're not exactly the same and I don't think we need to "replace" records as PUT suggests.