### PR TITLE
Switch to autoload in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,21 @@ module TopologicalInventory
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-    config.autoload_paths << Rails.root.join('lib')
+
+    # Disabling eagerload in production in favor of autoload
+    config.autoload_paths += config.eager_load_paths
+
+    # NOTE:  If you are going to make changes to autoload_paths, please make
+    # sure they are all strings.  Rails will push these paths into the
+    # $LOAD_PATH.
+    #
+    # More info can be found in the ruby-lang bug:
+    #
+    #   https://bugs.ruby-lang.org/issues/14372
+    #
+    config.autoload_paths << Rails.root.join("app", "models", "mixins").to_s
+    config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
+    config.autoload_paths << Rails.root.join("lib").to_s
 
     ManageIQ::API::Common::Logging.activate(config)
     ManageIQ::API::Common::Metrics.activate(config, "topological_inventory_api")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,11 +4,14 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
-  # Eager load code on boot. This eager loads most of Rails and
+  # Don't eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
+  # Enabling eagerloading also disables autoloading which causes problems
+  # in production that don't happen in development.
+  config.eager_load_paths = []
+  config.eager_load = false
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,3 +1,2 @@
 module Api
-  Docs = ::OpenApi::Docs.new(Dir.glob(Rails.root.join("public/doc/swagger*.yaml")))
 end

--- a/lib/api/docs.rb
+++ b/lib/api/docs.rb
@@ -1,0 +1,3 @@
+module Api
+  Docs = ::OpenApi::Docs.new(Dir.glob(Rails.root.join("public/doc/swagger*.yaml")))
+end


### PR DESCRIPTION
Started GET \"/r/insights/platform/topological-inventory/v0.1/sources\" for 52.36.139.101 at 2019-01-25 14:12:41 +0000
Processing by Api::V0x1::SourcesController#index as */*
Completed 500 Internal Server Error in 4ms (ActiveRecord: 0.0ms)
NameError (uninitialized constant ManageIQ::API::Common::PaginatedResponse):
app/controllers/api/v0x1/mixins/index_mixin.rb:6:in `index'

Eagerload is disabling autoload causing errors in production that are not seen in development.