### PR TITLE
Enforce tenancy

### DIFF
--- a/app/controllers/api/v0/sources_controller.rb
+++ b/app/controllers/api/v0/sources_controller.rb
@@ -6,6 +6,13 @@ module Api
       include Api::V0::Mixins::ShowMixin
       include Api::V0::Mixins::UpdateMixin
 
+      def set_the_current_tenant
+        # Auto-create tenant if creating a new source and tenant does not exist
+        Tenant.find_or_create_by(:external_tenant => user_identity) if action_name == "create"
+
+        super
+      end
+
       def create
         source = Source.create!(params_for_create.merge!("uid" => SecureRandom.uuid))
         render :json => source, :status => :created, :location => instance_link(source)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,48 @@ class ApplicationController < ActionController::API
   end
 
   private
+  set_current_tenant_through_filter
+  before_action :set_the_current_tenant
+
+  def set_the_current_tenant
+    return unless ENV["ENFORCE_TENANCY"]
+
+    tenant = Tenant.find_by(:external_tenant => user_identity)
+    if tenant
+      set_current_tenant(tenant)
+    else
+      error_document = {
+          "errors" => [
+              {
+                  "status" => "401",
+                  "detail" => "Account number not present or not found"
+              }
+          ]
+      }
+      render :json => error_document, :status => :unauthorized
+    end
+  end
+
+  def user_account_number
+    Base64.decode64(request.headers.fetch_path("x-rh-identity", "identity", "account_number"))
+  end
+
+  def user_identity
+    # x-rh-identity = {
+    #     "identity" => {
+    #         "account_number" => 123456,
+    #         "type" => "String"
+    #     },
+    #     "user" => {},
+    #     "system" => {},
+    #     "internal" => {},
+    # }
+    ident_key = "x-rh-identity"
+    return unless request.headers.key?(ident_key)
+
+    ident = JSON.parse(Base64.decode64(request.headers[ident_key]))
+    ident.fetch_path("identity", "account_number")
+  end
 
   private_class_method def self.model
     @model ||= controller_name.classify.constantize

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::API
   before_action :set_the_current_tenant
 
   def set_the_current_tenant
-    return unless ENV["ENFORCE_TENANCY"]
+    return unless Tenant.tenancy_enabled?
 
     tenant = Tenant.find_by(:external_tenant => user_identity)
     if tenant
@@ -29,19 +29,15 @@ class ApplicationController < ActionController::API
     end
   end
 
-  def user_account_number
-    Base64.decode64(request.headers.fetch_path("x-rh-identity", "identity", "account_number"))
-  end
-
   def user_identity
-    # x-rh-identity = {
-    #     "identity" => {
-    #         "account_number" => 123456,
-    #         "type" => "String"
-    #     },
+    # "x-rh-identity" => {
+    #   "identity" => {
+    #     "account_number" => 123456,
     #     "user" => {},
     #     "system" => {},
     #     "internal" => {},
+    #     "type" => "String"
+    #   }
     # }
     ident_key = "x-rh-identity"
     return unless request.headers.key?(ident_key)

--- a/spec/controllers/api/v0x0/application_controller_spec.rb
+++ b/spec/controllers/api/v0x0/application_controller_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe ApplicationController, :type => :request do
+
+  let(:tenant)          { Tenant.create!(:external_tenant => external_tenant) }
+  let(:source_type)     { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+  let(:source)          { Source.create!(:source_type_id => source_type.id, :tenant_id => tenant.id , :name => "abc", :uid => "123") }
+  let(:external_tenant) { rand(1000).to_s }
+  let(:identity)        { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
+
+  context "with tenancy enforcement" do
+    before { stub_const("ENV", "ENFORCE_TENANCY" => "true") }
+    after  { controller.send(:set_current_tenant,  nil) }
+
+    it "get /source with tenant" do
+      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
+
+      get("/api/v0.0/sources/#{source.id}", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to include("id" => source.id.to_s)
+    end
+
+    it "get /source without tenant" do
+      headers = { "CONTENT_TYPE" => "application/json" }
+
+      get("/api/v0.0/sources/#{source.id}", :headers => headers)
+
+      expect(response.status).to eq(401)
+    end
+
+    it "get /sources with tenant" do
+      source
+      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
+
+      get("/api/v0.0/sources", :headers => headers)
+
+      expect(response.status).to eq(200)
+    end
+
+    it "get /sources without tenant" do
+      headers = { "CONTENT_TYPE" => "application/json" }
+
+      get("/api/v0.0/sources", :headers => headers)
+
+      expect(response.status).to eq(401)
+    end
+  end
+
+  context "without tenancy enforcement" do
+    after { controller.send(:set_current_tenant,  nil) }
+
+    it "get /sources" do
+      headers = { "CONTENT_TYPE" => "application/json" }
+
+      get("/api/v0.0/sources", :headers => headers)
+
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/controllers/api/v0x0/application_controller_spec.rb
+++ b/spec/controllers/api/v0x0/application_controller_spec.rb
@@ -1,13 +1,10 @@
 RSpec.describe ApplicationController, :type => :request do
-
-  let(:tenant)           { Tenant.create!(:external_tenant => external_tenant) }
-  let(:source_type)      { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let!(:source)          { Source.create!(:source_type_id => source_type.id, :tenant_id => tenant.id , :name => "abc", :uid => "123") }
-  let(:external_tenant)  { rand(1000).to_s }
-  let(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
-  let(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => '123abc'}}.to_json) }
+  include ::Spec::Support::TenantIdentity
+  let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+  let!(:source)     { Source.create!(:source_type_id => source_type.id, :tenant_id => tenant.id , :name => "abc", :uid => "123") }
 
   context "with tenancy enforcement" do
+    before { stub_const("ENV", "BYPASS_TENANCY" => nil) }
     after  { controller.send(:set_current_tenant,  nil) }
 
     it "get /source with tenant" do

--- a/spec/controllers/api/v0x0/authentications_controller_spec.rb
+++ b/spec/controllers/api/v0x0/authentications_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V0x0::AuthenticationsController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }
@@ -7,11 +9,13 @@ RSpec.describe Api::V0x0::AuthenticationsController, :type => :request do
   let(:endpoint)    { Endpoint.create!(:source => source, :tenant => tenant) }
   let(:source)      { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
   let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let(:tenant)      { Tenant.create! }
 
   it "post /authentications creates an Authentication" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x0_authentications_url, :params => {:tenant_id => tenant.id.to_s, :resource_type => "Endpoint", :resource_id => endpoint.id, :name => "abc", :username => "aaa", :password => "xxx"}.to_json)
+    post(api_v0x0_authentications_url,
+         :headers => {"x-rh-identity" => identity},
+         :params => {:tenant_id => tenant.id.to_s, :resource_type => "Endpoint", :resource_id => endpoint.id, :name => "abc", :username => "aaa", :password => "xxx"}.to_json
+    )
 
     authentication = Authentication.first
 

--- a/spec/controllers/api/v0x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x0/endpoints_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V0x0::EndpointsController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }
@@ -6,13 +8,13 @@ RSpec.describe Api::V0x0::EndpointsController, :type => :request do
 
   let(:source)      { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
   let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let(:tenant)      { Tenant.create! }
 
   it "post /endpoints creates an Endpoint" do
     headers = { "CONTENT_TYPE" => "application/json" }
     post(
       api_v0x0_endpoints_url,
-      :params => {
+      :headers => {"x-rh-identity" => identity},
+      :params  => {
         :host                  => "example.com",
         :port                  => "443",
         :role                  => "default",

--- a/spec/controllers/api/v0x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v0x0/mixins/destroy_mixin_spec.rb
@@ -1,11 +1,12 @@
 describe Api::V0::Mixins::DestroyMixin do
+  include ::Spec::Support::TenantIdentity
+
   describe Api::V0x0::SourcesController, :type => :request do
     let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
-    let!(:tenant)     { Tenant.create! }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
 
     it "Primary Collection: delete /sources/:id destroys a Source" do
-      delete(api_v0x0_source_url(source_1.id))
+      delete(api_v0x0_source_url(source_1.id), :headers => {"x-rh-identity" => identity})
 
       expect(response.status).to eq(204)
       expect(response.parsed_body).to be_empty
@@ -15,7 +16,7 @@ describe Api::V0::Mixins::DestroyMixin do
       let!(:endpoint_1) { Endpoint.create!(:role => "a", :source => source_1, :tenant => tenant) }
 
       it "delete /sources/:id/endpoint/:id fails with 404" do
-        delete(api_v0x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}")
+        delete(api_v0x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(404)
       end

--- a/spec/controllers/api/v0x0/mixins/index_mixin_spec.rb
+++ b/spec/controllers/api/v0x0/mixins/index_mixin_spec.rb
@@ -1,12 +1,12 @@
 describe Api::V0::Mixins::IndexMixin do
   describe Api::V0x0::SourcesController, :type => :request do
+    include ::Spec::Support::TenantIdentity
     let!(:source_1)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
     let!(:source_2)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
     let!(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-    let!(:tenant)      { Tenant.create! }
 
     it "Primary Collection: get /sources lists all Sources" do
-      get(api_v0x0_sources_url)
+      get(api_v0x0_sources_url, :headers => {"x-rh-identity" => identity})
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to match([a_hash_including("id" => source_1.id.to_s), a_hash_including("id" => source_2.id.to_s)])
@@ -18,7 +18,7 @@ describe Api::V0::Mixins::IndexMixin do
       let!(:endpoint_3) { Endpoint.create!(:role => "c", :source => source_2, :tenant => tenant) }
 
       it "get /sources/:id/endpoints lists all Endpoints for a source" do
-        get(api_v0x0_source_endpoints_url(source_1.id))
+        get(api_v0x0_source_endpoints_url(source_1.id), :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(200)
         expect(response.parsed_body).to match([a_hash_including("id" => endpoint_1.id.to_s), a_hash_including("id" => endpoint_2.id.to_s)])

--- a/spec/controllers/api/v0x0/mixins/show_mixin_spec.rb
+++ b/spec/controllers/api/v0x0/mixins/show_mixin_spec.rb
@@ -1,12 +1,13 @@
 describe Api::V0::Mixins::ShowMixin do
+  include ::Spec::Support::TenantIdentity
+
   describe Api::V0x0::SourcesController, :type => :request do
     let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
     let!(:source_2)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
-    let!(:tenant)     { Tenant.create! }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
 
     it "Primary Collection: get /sources lists all Sources" do
-      get(api_v0x0_source_url(source_1.id))
+      get(api_v0x0_source_url(source_1.id), :headers => {"x-rh-identity" => identity})
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to include("id" => source_1.id.to_s, "name" => source_1.name)
@@ -16,7 +17,7 @@ describe Api::V0::Mixins::ShowMixin do
       let!(:endpoint_1) { Endpoint.create!(:role => "a", :source => source_1, :tenant => tenant) }
 
       it "get /sources/:id/endpoints/:id doesn't exist" do
-        get(api_v0x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}")
+        get(api_v0x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(404)
       end

--- a/spec/controllers/api/v0x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v0x0/mixins/update_mixin_spec.rb
@@ -1,12 +1,13 @@
 describe Api::V0::Mixins::UpdateMixin do
+  include ::Spec::Support::TenantIdentity
+
   describe Api::V0x0::SourcesController, :type => :request do
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-    let(:tenant)      { Tenant.create! }
 
     it "patch /sources/:id updates a Source" do
       source = Source.create!(:source_type => source_type, :tenant => tenant, :name => "abc", :uid => SecureRandom.uuid)
 
-      patch(api_v0x0_source_url(source.id), :params => {:name => "xyz"}.to_json)
+      patch(api_v0x0_source_url(source.id), :params => {:name => "xyz"}.to_json, :headers => {"x-rh-identity" => identity})
 
       expect(source.reload.name).to eq("xyz")
 

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses IndexMixin") { expect(described_class.instance_method(:index).owner).to eq(Api::V0::Mixins::IndexMixin) }
   it("Uses ShowMixin")  { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }
 
@@ -18,7 +20,6 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
     end
     let(:source_region) { SourceRegion.create!(:tenant => tenant, :source => source, :source_ref => SecureRandom.uuid) }
     let(:source) { Source.create!(:tenant => tenant, :source_type => source_type, :uid => SecureRandom.uuid, :name => "test_source") }
-    let(:tenant) { Tenant.create! }
     let(:subscription) { Subscription.create!(:tenant => tenant, :source => source, :source_ref => SecureRandom.uuid) }
     let(:service_offering) do
       ServiceOffering.create!(
@@ -50,7 +51,7 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
           "provider_control_parameters" => provider_control_parameters
         }
 
-        post "/api/v0.0/service_plans/#{service_plan.id}/order", :params => payload
+        post "/api/v0.0/service_plans/#{service_plan.id}/order", :params => payload, :headers => {"x-rh-identity" => identity}
 
         @body = JSON.parse(response.body)
       end
@@ -66,7 +67,7 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
 
     context "with a malicious service plan id" do
       it "returns an error" do
-        post "/api/v0.0/service_plans/;myfakeSQLinjection/order"
+        post "/api/v0.0/service_plans/;myfakeSQLinjection/order", :headers => {"x-rh-identity" => identity}
 
         expect(response.status).to eq(400)
       end

--- a/spec/controllers/api/v0x0/source_types_controller_spec.rb
+++ b/spec/controllers/api/v0x0/source_types_controller_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe Api::V0x0::SourceTypesController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }
 
   it "post /sources creates a Source" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x0_source_types_url, :params => {:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat"}.to_json)
+    post(api_v0x0_source_types_url, :headers => {"x-rh-identity" => identity}, :params => {:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat"}.to_json)
 
     source_type = SourceType.first
 

--- a/spec/controllers/api/v0x0/sources_controller_spec.rb
+++ b/spec/controllers/api/v0x0/sources_controller_spec.rb
@@ -1,15 +1,18 @@
 RSpec.describe Api::V0x0::SourcesController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }
   it("Uses UpdateMixin")  { expect(described_class.instance_method(:update).owner).to eq(Api::V0::Mixins::UpdateMixin) }
 
   let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let(:tenant)      { Tenant.create! }
 
   it "post /sources creates a Source" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x0_sources_url, :params => {:source_type_id => source_type.id.to_s, :tenant_id => tenant.id.to_s, :name => "abc"}.to_json)
+    post(api_v0x0_sources_url,
+         :headers => {"x-rh-identity" => identity},
+         :params => {:source_type_id => source_type.id.to_s, :tenant_id => tenant.id.to_s, :name => "abc"}.to_json)
 
     source = Source.first
 

--- a/spec/controllers/api/v0x1/authentications_controller_spec.rb
+++ b/spec/controllers/api/v0x1/authentications_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V0x1::AuthenticationsController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses CreateMixin")  { expect(described_class.instance_method(:create).owner).to eq(Api::V0x1::Mixins::CreateMixin) }
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0x1::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0x1::Mixins::IndexMixin) }
@@ -8,11 +10,13 @@ RSpec.describe Api::V0x1::AuthenticationsController, :type => :request do
   let(:endpoint)    { Endpoint.create!(:source => source, :tenant => tenant) }
   let(:source)      { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
   let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let(:tenant)      { Tenant.create! }
 
   it "post /authentications creates an Authentication" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x1_authentications_url, :params => {:tenant_id => tenant.id.to_s, :resource_type => "Endpoint", :resource_id => endpoint.id, :name => "abc", :username => "aaa", :password => "xxx"}.to_json)
+    post(api_v0x1_authentications_url,
+         :headers => {"x-rh-identity" => identity},
+         :params => {:tenant_id => tenant.id.to_s, :resource_type => "Endpoint", :resource_id => endpoint.id, :name => "abc", :username => "aaa", :password => "xxx"}.to_json
+    )
 
     authentication = Authentication.first
 

--- a/spec/controllers/api/v0x1/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x1/endpoints_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V0x1::EndpointsController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses CreateMixin")  { expect(described_class.instance_method(:create).owner).to eq(Api::V0x1::Mixins::CreateMixin) }
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0x1::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0x1::Mixins::IndexMixin) }
@@ -7,12 +9,12 @@ RSpec.describe Api::V0x1::EndpointsController, :type => :request do
 
   let(:source)      { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
   let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let(:tenant)      { Tenant.create! }
 
   it "post /endpoints creates an Endpoint" do
     headers = { "CONTENT_TYPE" => "application/json" }
     post(
       api_v0x1_endpoints_url,
+      :headers => {"x-rh-identity" => identity},
       :params => {
         :host                  => "example.com",
         :port                  => "443",

--- a/spec/controllers/api/v0x1/mixins/create_mixin_spec.rb
+++ b/spec/controllers/api/v0x1/mixins/create_mixin_spec.rb
@@ -1,7 +1,12 @@
 describe Api::V0x1::Mixins::CreateMixin do
   describe Api::V0x1::SourcesController, :type => :request do
+    include ::Spec::Support::TenantIdentity
+
     it "extra body parameters raise an error" do
-      post(api_v0x1_sources_url, :params => {"name" => "abc", "garbage" => "not accepted"}.to_json)
+      post(api_v0x1_sources_url,
+           :headers => {"x-rh-identity" => identity},
+           :params => {"name" => "abc", "garbage" => "not accepted"}.to_json
+      )
 
       expect(response.status).to eq(400)
       expect(response.parsed_body).to eq(

--- a/spec/controllers/api/v0x1/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v0x1/mixins/destroy_mixin_spec.rb
@@ -1,11 +1,12 @@
 describe Api::V0x1::Mixins::DestroyMixin do
+  include ::Spec::Support::TenantIdentity
+
   describe Api::V0x1::SourcesController, :type => :request do
     let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
-    let!(:tenant)     { Tenant.create! }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
 
     it "Primary Collection: delete /sources/:id destroys a Source" do
-      delete(api_v0x1_source_url(source_1.id))
+      delete(api_v0x1_source_url(source_1.id), :headers => {"x-rh-identity" => identity})
 
       expect(response.status).to eq(204)
       expect(response.parsed_body).to be_empty
@@ -15,7 +16,7 @@ describe Api::V0x1::Mixins::DestroyMixin do
       let!(:endpoint_1) { Endpoint.create!(:role => "a", :source => source_1, :tenant => tenant) }
 
       it "delete /sources/:id/endpoint/:id fails with 404" do
-        delete(api_v0x1_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}")
+        delete(api_v0x1_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(404)
       end

--- a/spec/controllers/api/v0x1/mixins/index_mixin_spec.rb
+++ b/spec/controllers/api/v0x1/mixins/index_mixin_spec.rb
@@ -1,12 +1,13 @@
 describe Api::V0x1::Mixins::IndexMixin do
+  include ::Spec::Support::TenantIdentity
+
   describe Api::V0x1::SourcesController, :type => :request do
     let!(:source_1)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
     let!(:source_2)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
     let!(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-    let!(:tenant)      { Tenant.create! }
 
     it "Primary Collection: get /sources lists all Sources" do
-      get(api_v0x1_sources_url)
+      get(api_v0x1_sources_url, :headers => {"x-rh-identity" => identity})
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["data"]).to match([a_hash_including("id" => source_1.id.to_s), a_hash_including("id" => source_2.id.to_s)])
@@ -18,7 +19,7 @@ describe Api::V0x1::Mixins::IndexMixin do
       let!(:endpoint_3) { Endpoint.create!(:role => "c", :source => source_2, :tenant => tenant) }
 
       it "get /sources/:id/endpoints lists all Endpoints for a source" do
-        get(api_v0x1_source_endpoints_url(source_1.id))
+        get(api_v0x1_source_endpoints_url(source_1.id), :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(200)
         expect(response.parsed_body["data"]).to match([a_hash_including("id" => endpoint_1.id.to_s), a_hash_including("id" => endpoint_2.id.to_s)])
@@ -27,14 +28,14 @@ describe Api::V0x1::Mixins::IndexMixin do
 
     context "paging" do
       it "response_structure" do
-        get(api_v0x1_sources_url)
+        get(api_v0x1_sources_url, :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(200)
         expect(response.parsed_body.keys).to eq(["meta", "links", "data"])
       end
 
       it "meta/count" do
-        get(api_v0x1_sources_url)
+        get(api_v0x1_sources_url, :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(200)
         expect(response.parsed_body["meta"]).to eq("count" => 2)

--- a/spec/controllers/api/v0x1/mixins/show_mixin_spec.rb
+++ b/spec/controllers/api/v0x1/mixins/show_mixin_spec.rb
@@ -1,12 +1,13 @@
 describe Api::V0::Mixins::ShowMixin do
+  include ::Spec::Support::TenantIdentity
+
   describe Api::V0x1::SourcesController, :type => :request do
     let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
     let!(:source_2)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
-    let!(:tenant)     { Tenant.create! }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
 
     it "Primary Collection: get /sources lists all Sources" do
-      get(api_v0x1_source_url(source_1.id))
+      get(api_v0x1_source_url(source_1.id), :headers => {"x-rh-identity" => identity})
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to include("id" => source_1.id.to_s, "name" => source_1.name)
@@ -16,7 +17,7 @@ describe Api::V0::Mixins::ShowMixin do
       let!(:endpoint_1) { Endpoint.create!(:role => "a", :source => source_1, :tenant => tenant) }
 
       it "get /sources/:id/endpoints/:id doesn't exist" do
-        get(api_v0x1_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}")
+        get(api_v0x1_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => {"x-rh-identity" => identity})
 
         expect(response.status).to eq(404)
       end

--- a/spec/controllers/api/v0x1/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v0x1/mixins/update_mixin_spec.rb
@@ -1,11 +1,12 @@
 describe Api::V0x1::Mixins::UpdateMixin do
+  include ::Spec::Support::TenantIdentity
+
   describe Api::V0x1::SourcesController, :type => :request do
     let(:source)      { Source.create!(:source_type => source_type, :tenant => tenant, :name => "abc", :uid => SecureRandom.uuid) }
     let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-    let(:tenant)      { Tenant.create! }
 
     it "patch /sources/:id updates a Source" do
-      patch(api_v0x1_source_url(source.id), :params => {:name => "xyz"}.to_json)
+      patch(api_v0x1_source_url(source.id), :params => {:name => "xyz"}.to_json, :headers => {"x-rh-identity" => identity})
 
       expect(source.reload.name).to eq("xyz")
 
@@ -14,7 +15,7 @@ describe Api::V0x1::Mixins::UpdateMixin do
     end
 
     it "extra body parameters raise an error" do
-      patch(api_v0x1_source_url(source.id), :params => {"name" => "abc", "garbage" => "not accepted"}.to_json)
+      patch(api_v0x1_source_url(source.id), :params => {"name" => "abc", "garbage" => "not accepted"}.to_json, :headers => {"x-rh-identity" => identity})
 
       expect(response.status).to eq(400)
       expect(response.parsed_body).to eq(

--- a/spec/controllers/api/v0x1/source_types_controller_spec.rb
+++ b/spec/controllers/api/v0x1/source_types_controller_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe Api::V0x1::SourceTypesController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0x1::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }
 
   it "post /sources creates a Source" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x1_source_types_url, :params => {:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat"}.to_json)
+    post(api_v0x1_source_types_url, :headers => {"x-rh-identity" => identity}, :params => {:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat"}.to_json)
 
     source_type = SourceType.first
 

--- a/spec/controllers/api/v0x1/sources_controller_spec.rb
+++ b/spec/controllers/api/v0x1/sources_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Api::V0x1::SourcesController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   it("Uses CreateMixin")  { expect(described_class.instance_method(:create).owner).to eq(Api::V0x1::Mixins::CreateMixin) }
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0x1::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0x1::Mixins::IndexMixin) }
@@ -6,11 +8,10 @@ RSpec.describe Api::V0x1::SourcesController, :type => :request do
   it("Uses UpdateMixin")  { expect(described_class.instance_method(:update).owner).to eq(Api::V0x1::Mixins::UpdateMixin) }
 
   let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let(:tenant)      { Tenant.create! }
 
   it "post /sources creates a Source" do
-    headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x1_sources_url, :params => {:source_type_id => source_type.id.to_s, :tenant_id => tenant.id.to_s, :name => "abc"}.to_json)
+    headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
+    post(api_v0x1_sources_url, :headers => headers, :params => {:source_type_id => source_type.id.to_s, :tenant_id => tenant.id.to_s, :name => "abc"}.to_json)
 
     source = Source.first
 

--- a/spec/controllers/api/v0x1/sources_controller_spec.rb
+++ b/spec/controllers/api/v0x1/sources_controller_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe Api::V0x1::SourcesController, :type => :request do
     expect(response.location).to match(a_string_ending_with("v0.1/sources/#{source.id}"))
     expect(response.parsed_body).to include("name" => "abc", "id" => source.id.to_s)
   end
+
+  it "post /sources creates a Source and Tenant when tenant does not exist" do
+    headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => unknown_identity }
+    post(api_v0x1_sources_url, :headers => headers, :params => {:source_type_id => source_type.id.to_s, :tenant_id => tenant.id.to_s, :name => "abc"}.to_json)
+
+    expect(Tenant.find_by(:external_tenant => unknown_tenant)).not_to be_nil
+    source = Source.first
+
+    expect(response.status).to eq(201)
+  end
 end

--- a/spec/controllers/internal/v0x0/authentications_controller_spec.rb
+++ b/spec/controllers/internal/v0x0/authentications_controller_spec.rb
@@ -1,12 +1,13 @@
 RSpec.describe Internal::V0x0::AuthenticationsController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
   let(:authentication) { Authentication.create!(:resource => endpoint, :tenant => tenant, :password => "abcdefg") }
   let(:endpoint)       { Endpoint.create!(:source => source, :tenant => tenant) }
   let(:source)         { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
   let(:source_type)    { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let(:tenant)         { Tenant.create! }
 
   it "GET an instance" do
-    get(internal_v0x0_authentication_url(authentication.id))
+    get(internal_v0x0_authentication_url(authentication.id), :headers => {"x-rh-identity" => identity})
 
     expect(response.status).to eq(200)
     expect(response.parsed_body).to include("id" => authentication.id.to_s, "resource_type" => "Endpoint", "resource_id" => endpoint.id.to_s)
@@ -14,7 +15,7 @@ RSpec.describe Internal::V0x0::AuthenticationsController, :type => :request do
   end
 
   it "GET an instance exposing password" do
-    get(internal_v0x0_authentication_url(authentication.id), :params => {"expose_encrypted_attribute[]" => "password"})
+    get(internal_v0x0_authentication_url(authentication.id), :headers => {"x-rh-identity" => identity}, :params => {"expose_encrypted_attribute[]" => "password"})
 
     expect(response.status).to eq(200)
     expect(response.parsed_body).to include("id" => authentication.id.to_s, "resource_type" => "Endpoint", "resource_id" => endpoint.id.to_s, "password" => "abcdefg")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,3 +96,4 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -1,0 +1,16 @@
+module Spec
+  module Support
+    module TenantIdentity
+      extend ActiveSupport::Concern
+
+      included do
+        after  { controller.send(:set_current_tenant,  nil) if controller }
+
+        let!(:tenant)           { Tenant.create!(:external_tenant => external_tenant) }
+        let!(:external_tenant)  { rand(1000).to_s }
+        let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
+        let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => '123abc'}}.to_json) }
+      end
+    end
+  end
+end

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -8,8 +8,9 @@ module Spec
 
         let!(:tenant)           { Tenant.create!(:external_tenant => external_tenant) }
         let!(:external_tenant)  { rand(1000).to_s }
+        let!(:unknown_tenant)   { rand(1000).to_s }
         let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
-        let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => '123abc'}}.to_json) }
+        let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => unknown_tenant}}.to_json) }
       end
     end
   end


### PR DESCRIPTION
First pass at enforcing tenancy

Tenancy enforcement requires the environment variable `ENFORCE_TENANCY` to be set to "true". Otherwise no enforcement will be done. The default behavior is NOT enforce tenancy.

https://projects.engineering.redhat.com/browse/TPINVTRY-127