### PR TITLE
Allow for path-only redirect links in the router

### DIFF
--- a/config/initializers/action_dispatch-routing-option_redirect.rb
+++ b/config/initializers/action_dispatch-routing-option_redirect.rb
@@ -1,0 +1,20 @@
+module OptionRedirectEnhancements
+  def serve(req)
+    uri = URI.parse(path(req.path_parameters, req))
+
+    req.commit_flash
+
+    body = %(<html><body>You are being <a href="#{ERB::Util.unwrapped_html_escape(uri.to_s)}">redirected</a>.</body></html>)
+
+    headers = {
+      "Location" => uri.to_s,
+      "Content-Type" => "text/html",
+      "Content-Length" => body.length.to_s
+    }
+
+    [ status, headers, [body] ]
+  end
+end
+
+require 'action_dispatch/routing/redirection'
+ActionDispatch::Routing::OptionRedirect.prepend(OptionRedirectEnhancements)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
 
   scope :as => :api, :module => "api", :path => prefix do
-    match "/v0/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect("#{prefix}/v0.0/%{path}")
+    match "/v0/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect(:path => "/#{prefix}/v0.0/%{path}", :only_path => true)
 
     namespace :v0x1, :path => "v0.1" do
       resources :authentications,         :only => [:create, :destroy, :index, :show, :update]


### PR DESCRIPTION
This is necessary for the 3scale API gateway to allow redirects.  The location can't include the hostname.