### PR TITLE
Validate create params

### DIFF
--- a/app/controllers/api/v0/authentications_controller.rb
+++ b/app/controllers/api/v0/authentications_controller.rb
@@ -7,15 +7,11 @@ module Api
       include Api::V0::Mixins::UpdateMixin
 
       def create
-        authentication = model.create!(create_params)
+        authentication = model.create!(params_for_create)
         render :json => authentication, :status => :created, :location => instance_link(authentication)
       end
 
       private
-
-      def create_params
-        body_params.permit(:tenant_id, :authtype, :name, :password, :resource_type, :resource_id, :username)
-      end
 
       def update_params
         params.permit(:authtype, :name, :password, :username)

--- a/app/controllers/api/v0/authentications_controller.rb
+++ b/app/controllers/api/v0/authentications_controller.rb
@@ -14,11 +14,11 @@ module Api
       private
 
       def update_params
-        params.permit(:authtype, :name, :password, :username)
+        params.permit(:authtype, :name, :password, :username, :id)
       end
 
       def list_params
-        params.permit(:tenant_id, :authtype, :name, :resource_type, :resource_id, :status, :status_details, :username)
+        params.permit(:tenant_id, :authtype, :name, :resource_type, :resource_id, :status, :status_details, :username, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/container_groups_controller.rb
+++ b/app/controllers/api/v0/container_groups_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id, :container_project_id, :container_node_id)
+        params.permit(:source_id, :tenant_id, :container_project_id, :container_node_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/container_images_controller.rb
+++ b/app/controllers/api/v0/container_images_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/container_nodes_controller.rb
+++ b/app/controllers/api/v0/container_nodes_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/container_projects_controller.rb
+++ b/app/controllers/api/v0/container_projects_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/container_templates_controller.rb
+++ b/app/controllers/api/v0/container_templates_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id, :container_project_id)
+        params.permit(:source_id, :tenant_id, :container_project_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/containers_controller.rb
+++ b/app/controllers/api/v0/containers_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:tenant_id, :container_group_id)
+        params.permit(:tenant_id, :container_group_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/endpoints_controller.rb
+++ b/app/controllers/api/v0/endpoints_controller.rb
@@ -7,15 +7,11 @@ module Api
       include Api::V0::Mixins::UpdateMixin
 
       def create
-        endpoint = Endpoint.create!(create_params)
+        endpoint = Endpoint.create!(params_for_create)
         render :json => endpoint, :status => :created, :location => instance_link(endpoint)
       end
 
       private
-
-      def create_params
-        body_params.permit(:role, :port, :source_id, :default, :scheme, :host, :path, :tenant_id)
-      end
 
       def update_params
         params.permit(:role, :port, :source_id, :default, :scheme, :host, :path)

--- a/app/controllers/api/v0/endpoints_controller.rb
+++ b/app/controllers/api/v0/endpoints_controller.rb
@@ -9,16 +9,17 @@ module Api
       def create
         endpoint = Endpoint.create!(params_for_create)
         render :json => endpoint, :status => :created, :location => instance_link(endpoint)
+
       end
 
       private
 
       def update_params
-        params.permit(:role, :port, :source_id, :default, :scheme, :host, :path)
+        params.permit(:role, :port, :source_id, :default, :scheme, :host, :path, :id)
       end
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/flavors_controller.rb
+++ b/app/controllers/api/v0/flavors_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/orchestration_stacks_controller.rb
+++ b/app/controllers/api/v0/orchestration_stacks_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/service_instances_controller.rb
+++ b/app/controllers/api/v0/service_instances_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id, :service_offering_id, :service_plan_id)
+        params.permit(:source_id, :tenant_id, :service_offering_id, :service_plan_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/service_offerings_controller.rb
+++ b/app/controllers/api/v0/service_offerings_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/service_plans_controller.rb
+++ b/app/controllers/api/v0/service_plans_controller.rb
@@ -5,7 +5,7 @@ module Api
       include Api::V0::Mixins::ShowMixin
 
       def order
-        service_plan = model.find(service_plan_id)
+        service_plan = model.find(order_params[:service_plan_id].to_i)
         task = Task.create!(:tenant => service_plan.tenant, :status => "started")
 
         #TODO: Publish a message with service plan ordering messaging client and simply
@@ -20,24 +20,21 @@ module Api
       private
 
       def order_service_plan_and_update_task(task, service_plan)
-        task.context = service_plan.order(order_params)
+        task.context = service_plan.order(order_params.slice(:service_parameters, :provider_control_parameters))
         task.status = "completed"
         task.save!
       end
 
-      def service_plan_id
-        params[:service_plan_id].to_i
-      end
-
       def order_params
         params.permit(
+          :service_plan_id,
           :service_parameters          => {},
           :provider_control_parameters => {}
         ).to_h
       end
 
       def list_params
-        params.permit(:source_id, :tenant_id, :service_offering_id)
+        params.permit(:source_id, :tenant_id, :service_offering_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/source_types_controller.rb
+++ b/app/controllers/api/v0/source_types_controller.rb
@@ -16,7 +16,7 @@ module Api
       end
 
       def list_params
-        params.permit(:name, :product_name, :vendor)
+        params.permit(:name, :product_name, :vendor, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/sources_controller.rb
+++ b/app/controllers/api/v0/sources_controller.rb
@@ -7,15 +7,11 @@ module Api
       include Api::V0::Mixins::UpdateMixin
 
       def create
-        source = Source.create!(create_params.merge!("uid" => SecureRandom.uuid))
+        source = Source.create!(params_for_create.merge!("uid" => SecureRandom.uuid))
         render :json => source, :status => :created, :location => instance_link(source)
       end
 
       private
-
-      def create_params
-        body_params.permit(:name, :source_type_id, :tenant_id)
-      end
 
       def update_params
         params.permit(:name)

--- a/app/controllers/api/v0/sources_controller.rb
+++ b/app/controllers/api/v0/sources_controller.rb
@@ -14,11 +14,11 @@ module Api
       private
 
       def update_params
-        params.permit(:name)
+        params.permit(:name, :id)
       end
 
       def list_params
-        params.permit(:tenant_id, :source_type_id)
+        params.permit(:tenant_id, :source_type_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/tasks_controller.rb
+++ b/app/controllers/api/v0/tasks_controller.rb
@@ -5,7 +5,7 @@ module Api
       include Api::V0::Mixins::ShowMixin
 
       def list_params
-        params.permit(:tenant_id)
+        params.permit(:tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/vms_controller.rb
+++ b/app/controllers/api/v0/vms_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/volume_attachments_controller.rb
+++ b/app/controllers/api/v0/volume_attachments_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:tenant_id, :vm_id, :volume_id)
+        params.permit(:tenant_id, :vm_id, :volume_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/volume_types_controller.rb
+++ b/app/controllers/api/v0/volume_types_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0/volumes_controller.rb
+++ b/app/controllers/api/v0/volumes_controller.rb
@@ -7,7 +7,7 @@ module Api
       private
 
       def list_params
-        params.permit(:source_id, :tenant_id)
+        params.permit(:source_id, :tenant_id, :limit, :offset)
       end
     end
   end

--- a/app/controllers/api/v0x1.rb
+++ b/app/controllers/api/v0x1.rb
@@ -1,6 +1,7 @@
 module Api
   module V0x1
     class AuthenticationsController < Api::V0x0::AuthenticationsController
+      include Api::V0x1::Mixins::CreateMixin
       include Api::V0x1::Mixins::IndexMixin
     end
 
@@ -29,6 +30,7 @@ module Api
     end
 
     class EndpointsController < Api::V0x0::EndpointsController
+      include Api::V0x1::Mixins::CreateMixin
       include Api::V0x1::Mixins::IndexMixin
     end
 
@@ -57,10 +59,12 @@ module Api
     end
 
     class SourcesController < Api::V0x0::SourcesController
+      include Api::V0x1::Mixins::CreateMixin
       include Api::V0x1::Mixins::IndexMixin
     end
 
     class SourceTypesController < Api::V0x0::SourceTypesController
+      include Api::V0x1::Mixins::CreateMixin
       include Api::V0x1::Mixins::IndexMixin
     end
 

--- a/app/controllers/api/v0x1/mixins/create_mixin.rb
+++ b/app/controllers/api/v0x1/mixins/create_mixin.rb
@@ -1,0 +1,21 @@
+module Api
+  module V0x1
+    module Mixins
+      module CreateMixin
+        def create
+          super
+        rescue ActionController::UnpermittedParameters => error
+          error_document = {
+            "errors" => [
+              {
+                "status" => "400",
+                "detail" => "#{error.message} in POST body"
+              }
+            ]
+          }
+          render :json => error_document, :status => :bad_request
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v0x1/mixins/index_mixin.rb
+++ b/app/controllers/api/v0x1/mixins/index_mixin.rb
@@ -4,10 +4,10 @@ module Api
       module IndexMixin
         def index
           render json: ManageIQ::API::Common::PaginatedResponse.new(
-            base_query: scoped(model.where(list_params)),
+            base_query: scoped(model.where(list_params.except(:limit, :offset))),
             request: request,
-            limit: params.permit(:limit)[:limit],
-            offset: params.permit(:offset)[:offset]
+            limit: list_params[:limit],
+            offset: list_params[:offset]
           ).response
         end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::API
     @model ||= controller_name.classify.constantize
   end
 
+  private_class_method def self.api_doc_definition
+    @api_doc_definition ||= Api::Docs[api_version[1..-1].sub(/x/, ".")].definitions[model.name]
+  end
+
   private_class_method def self.api_version
     @api_version ||= name.split("::")[1].downcase
   end
@@ -18,6 +22,15 @@ class ApplicationController < ActionController::API
     endpoint = instance.class.name.downcase
     version  = self.class.send(:api_version)
     send("api_#{version}_#{endpoint}_url", instance.id)
+  end
+
+  def params_for_create
+    required = api_doc_definition.required_attributes
+    body_params.permit(*api_doc_definition.all_attributes).tap { |i| i.require(required) if required }
+  end
+
+  def api_doc_definition
+    self.class.send(:api_doc_definition)
   end
 
   def model

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,8 @@ class ApplicationController < ActionController::API
 
   private
 
-  def model
-    self.class.controller_name.classify.constantize
+  private_class_method def self.model
+    @model ||= controller_name.classify.constantize
   end
 
   def body_params
@@ -14,5 +14,9 @@ class ApplicationController < ActionController::API
     endpoint = instance.class.name.downcase
     version  = self.class.name.split("::")[1].downcase
     send("api_#{version}_#{endpoint}_url", instance.id)
+  end
+
+  def model
+    self.class.send(:model)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,13 +6,17 @@ class ApplicationController < ActionController::API
     @model ||= controller_name.classify.constantize
   end
 
+  private_class_method def self.api_version
+    @api_version ||= name.split("::")[1].downcase
+  end
+
   def body_params
     ActionController::Parameters.new(JSON.parse(request.body.read))
   end
 
   def instance_link(instance)
     endpoint = instance.class.name.downcase
-    version  = self.class.name.split("::")[1].downcase
+    version  = self.class.send(:api_version)
     send("api_#{version}_#{endpoint}_url", instance.id)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  ActionController::Parameters.action_on_unpermitted_parameters = :raise
 
   private
 

--- a/lib/open_api/docs/doc_v2.rb
+++ b/lib/open_api/docs/doc_v2.rb
@@ -13,7 +13,9 @@ module OpenApi
       end
 
       def definitions
-        @definitions ||= substitute_regexes(content["definitions"])
+        @definitions ||= substitute_regexes(content["definitions"]).tap do |h|
+          h.each { |name, v| h[name] = OpenApi::Docs::ObjectDefinition.new.replace(v) }
+        end
       end
 
       def parameters

--- a/lib/open_api/docs/object_definition.rb
+++ b/lib/open_api/docs/object_definition.rb
@@ -1,0 +1,13 @@
+module OpenApi
+  class Docs
+    class ObjectDefinition < Hash
+      def all_attributes
+        self["properties"].keys
+      end
+
+      def required_attributes
+        self["required"]
+      end
+    end
+  end
+end

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1313,6 +1313,8 @@ definitions:
       username:
         type: string
         example: user@example.com
+      password:
+        type: string
   Container:
     type: object
     properties:

--- a/public/doc/swagger-2-v0.1.0.yaml
+++ b/public/doc/swagger-2-v0.1.0.yaml
@@ -1351,6 +1351,8 @@ definitions:
       username:
         type: string
         example: user@example.com
+      password:
+        type: string
   AuthenticationsCollection:
     type: object
     properties:

--- a/spec/controllers/api/v0x1/authentications_controller_spec.rb
+++ b/spec/controllers/api/v0x1/authentications_controller_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Api::V0x1::AuthenticationsController, :type => :request do
+  it("Uses CreateMixin")  { expect(described_class.instance_method(:create).owner).to eq(Api::V0x1::Mixins::CreateMixin) }
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0x1::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }

--- a/spec/controllers/api/v0x1/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x1/endpoints_controller_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Api::V0x1::EndpointsController, :type => :request do
+  it("Uses CreateMixin")  { expect(described_class.instance_method(:create).owner).to eq(Api::V0x1::Mixins::CreateMixin) }
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0x1::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }

--- a/spec/controllers/api/v0x1/mixins/create_mixin_spec.rb
+++ b/spec/controllers/api/v0x1/mixins/create_mixin_spec.rb
@@ -1,0 +1,14 @@
+describe Api::V0x1::Mixins::CreateMixin do
+  describe Api::V0x1::SourcesController, :type => :request do
+    it "extra body parameters raise an error" do
+      post(api_v0x1_sources_url, :params => {"name" => "abc", "garbage" => "not accepted"}.to_json)
+
+      expect(response.status).to eq(400)
+      expect(response.parsed_body).to eq(
+        "errors" => [
+          {"detail" => "found unpermitted parameter: :garbage in POST body", "status" => "400"}
+        ]
+      )
+    end
+  end
+end

--- a/spec/controllers/api/v0x1/sources_controller_spec.rb
+++ b/spec/controllers/api/v0x1/sources_controller_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Api::V0x1::SourcesController, :type => :request do
+  it("Uses CreateMixin")  { expect(described_class.instance_method(:create).owner).to eq(Api::V0x1::Mixins::CreateMixin) }
   it("Uses DestroyMixin") { expect(described_class.instance_method(:destroy).owner).to eq(Api::V0::Mixins::DestroyMixin) }
   it("Uses IndexMixin")   { expect(described_class.instance_method(:index).owner).to eq(Api::V0x1::Mixins::IndexMixin) }
   it("Uses ShowMixin")    { expect(described_class.instance_method(:show).owner).to eq(Api::V0::Mixins::ShowMixin) }


### PR DESCRIPTION
- Validate the params sent in POST requests against the object definition in the swagger file.
- Switch to `ActionController::Parameters.action_on_unpermitted_parameters = :raise`
  - Unfortunately this applies to the entire application and can't be changed one place at a time.
  - I'm planning a followup PR for to do the same for `list_params` and other methods, but I made the minimal change to not blow up for now.
- Return an error document as described in the [IPP](https://docs.google.com/document/d/1sEgro5-lXYJGsxOdxFOcyz7EHilrnpBVkHT_m2IXogk/edit#) and [JSON API](https://jsonapi.org/format/#errors) when incorrect or unexpected parameters are passed.