### PR TITLE
Add /internal/v0.0/authentications/:id api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'jbuilder',          '~> 2.0'
 gem 'json-schema',       '~> 2.8'
 gem 'manageiq-loggers',  '~> 0.1'
-gem 'manageiq-password', '~> 0.1'
+gem 'manageiq-password', '~> 0.2', ">= 0.2.1"
 gem 'pg',                '~> 1.0', :require => false
 gem 'puma',              '~> 3.0'
 gem 'rack-cors',         '>= 0.4.1'

--- a/app/controllers/internal/v0/authentications_controller.rb
+++ b/app/controllers/internal/v0/authentications_controller.rb
@@ -1,0 +1,28 @@
+module Internal
+  module V0
+    class AuthenticationsController < ::ApplicationController
+      def show
+        record = model.find(params_for_show[:id])
+        render json: record.as_json(:prefixes => [request.path]).merge(encrypted_attributes(record))
+      rescue ActiveRecord::RecordNotFound
+        head :not_found
+      end
+
+      private
+
+      def params_for_show
+        @params_for_show ||= params.permit(:id, :expose_encrypted_attribute => []).tap { |i| i.require(:id) }
+      end
+
+      def encrypted_attributes_to_expose
+        Array(params_for_show[:expose_encrypted_attribute].presence) & model.encrypted_columns
+      end
+
+      def encrypted_attributes(record)
+        encrypted_attributes_to_expose.each_with_object({}) do |attribute_name, h|
+          h[attribute_name] = record.public_send(attribute_name) if record.attributes.key?(attribute_name)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/internal/v0x0.rb
+++ b/app/controllers/internal/v0x0.rb
@@ -1,0 +1,5 @@
+module Internal
+  module V0x0
+    class AuthenticationsController < Internal::V0::AuthenticationsController; end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,4 +126,12 @@ Rails.application.routes.draw do
       resources :volumes,            :only => [:index, :show]
     end
   end
+
+  scope :as => :internal, :module => "internal", :path => "internal" do
+    match "/v0/*path", :via => [:get], :to => redirect(:path => "/internal/v0.0/%{path}", :only_path => true)
+
+    namespace :v0x0, :path => "v0.0" do
+      resources :authentications, :only => [:show]
+    end
+  end
 end

--- a/lib/open_api/serializer.rb
+++ b/lib/open_api/serializer.rb
@@ -5,17 +5,20 @@ module OpenApi
       encrypted_columns_set = (self.class.try(:encrypted_columns) || []).to_set
       encryption_filtered = previous.except(*encrypted_columns_set)
       return encryption_filtered unless arg.key?(:prefixes)
-      /\A\/?(?<api>\w+)\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ arg[:prefixes].first
-      version = [major, minor].compact.join(".")
+      version = api_version_from_prefix(arg[:prefixes].first)
       schema  = Api::Docs[version].definitions[self.class.name]
       attrs   = encryption_filtered.slice(*schema["properties"].keys)
-
       schema["properties"].keys.each do |name|
         attrs[name] = attrs[name].iso8601 if attrs[name].kind_of?(Time)
         attrs[name] = attrs[name].to_s if name.ends_with?("_id") || name == "id"
         attrs[name] = self.public_send(name) if !attrs.key?(name) && !encrypted_columns_set.include?(name)
       end
       attrs.compact
+    end
+
+    def api_version_from_prefix(prefix)
+      /\/?\w+\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ prefix
+      [major, minor].compact.join(".")
     end
   end
 end

--- a/lib/open_api/serializer.rb
+++ b/lib/open_api/serializer.rb
@@ -5,7 +5,7 @@ module OpenApi
       encrypted_columns_set = (self.class.try(:encrypted_columns) || []).to_set
       encryption_filtered = previous.except(*encrypted_columns_set)
       return encryption_filtered unless arg.key?(:prefixes)
-      /\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ arg[:prefixes].first
+      /\A\/?(?<api>\w+)\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ arg[:prefixes].first
       version = [major, minor].compact.join(".")
       schema  = Api::Docs[version].definitions[self.class.name]
       attrs   = encryption_filtered.slice(*schema["properties"].keys)

--- a/spec/controllers/internal/v0x0/authentications_controller_spec.rb
+++ b/spec/controllers/internal/v0x0/authentications_controller_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Internal::V0x0::AuthenticationsController, :type => :request do
+  let(:authentication) { Authentication.create!(:resource => endpoint, :tenant => tenant, :password => "abcdefg") }
+  let(:endpoint)       { Endpoint.create!(:source => source, :tenant => tenant) }
+  let(:source)         { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
+  let(:source_type)    { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+  let(:tenant)         { Tenant.create! }
+
+  it "GET an instance" do
+    get(internal_v0x0_authentication_url(authentication.id))
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body).to include("id" => authentication.id.to_s, "resource_type" => "Endpoint", "resource_id" => endpoint.id.to_s)
+    expect(response.parsed_body.keys).not_to include("password")
+  end
+
+  it "GET an instance exposing password" do
+    get(internal_v0x0_authentication_url(authentication.id), :params => {"expose_encrypted_attribute[]" => "password"})
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body).to include("id" => authentication.id.to_s, "resource_type" => "Endpoint", "resource_id" => endpoint.id.to_s, "password" => "abcdefg")
+  end
+end

--- a/spec/lib/open_api/serializing_spec.rb
+++ b/spec/lib/open_api/serializing_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe("Serializing ApplicationRecord instances to JSON") do
-  context "Encrypted attributes are not in the JSON response" do
-    let(:base_class) { Class.new.tap { |c| c.prepend(OpenApi::Serializer) } }
+  let(:base_class) { Class.new.tap { |c| c.prepend(OpenApi::Serializer) } }
 
+  context "Encrypted attributes are not in the JSON response" do
     it "on a model that has encrypted columns" do
       model = Class.new(base_class) do
         def self.encrypted_columns
@@ -16,7 +16,7 @@ RSpec.describe("Serializing ApplicationRecord instances to JSON") do
       expect(model.new.as_json).to eq("a" => 1, "b" => 2)
     end
 
-    it "on a model that has encrypted columns" do
+    it "on a model that does not have encrypted columns" do
       model = Class.new(base_class) do
         def to_hash
           {"a" => 1, "b" => 2, "secret" => "value"}
@@ -25,5 +25,14 @@ RSpec.describe("Serializing ApplicationRecord instances to JSON") do
 
       expect(model.new.as_json).to eq("a" => 1, "b" => 2, "secret" => "value")
     end
+  end
+
+  it "properly detects the version to serialize for" do
+    expect(base_class.new.api_version_from_prefix("api/v0.0/")).to eq("0.0")
+    expect(base_class.new.api_version_from_prefix("api/v0.0/something")).to eq("0.0")
+    expect(base_class.new.api_version_from_prefix("api/v0.1/something")).to eq("0.1")
+    expect(base_class.new.api_version_from_prefix("/api/v0.1/something")).to eq("0.1")
+    expect(base_class.new.api_version_from_prefix("a/b/v/v0.1/something")).to eq("0.1")
+    expect(base_class.new.api_version_from_prefix("/a/b/v/v0.1/something")).to eq("0.1")
   end
 end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -29,7 +29,8 @@ describe "Swagger stuff" do
 
       it "matches the routes" do
         redirect_routes = [{:path => "#{path_prefix}/#{app_name}/v0/*path", :verb => "DELETE|GET|OPTIONS|PATCH|POST"}]
-        expect(rails_routes).to match_array(swagger_routes + redirect_routes)
+        internal_api_routes = [{:path => "/internal/v0/*path", :verb => "GET"}, {:path=>"/internal/v0.0/authentications/:id", :verb=>"GET"}]
+        expect(rails_routes).to match_array(swagger_routes + redirect_routes + internal_api_routes)
       end
     end
 


### PR DESCRIPTION
- Add redirect for /internal/v0/* to /internal/v0.0/*
- Upgrade to manageiq-password v0.2.1 with corrected .encrypted_columns
- Allow `GET /internal/v0.0/authentications/1?expose_encrypted_attribute[]=password` to merge the unencrypted password into the response object
- For security purposes it's only on 1 instance and you must know the name of the attribute you're asking for and it's not exposed through the 3scale gateway, so you must hit the service directly.

https://projects.engineering.redhat.com/browse/TPINVTRY-165