### PR TITLE
Add /v*/openapi.json to fetch the swagger yaml

### DIFF
--- a/app/controllers/api/v0x1.rb
+++ b/app/controllers/api/v0x1.rb
@@ -1,5 +1,11 @@
 module Api
   module V0x1
+    class RootController < ApplicationController
+      def openapi
+        render :json => Api::Docs["0.1"].to_json
+      end
+    end
+
     class AuthenticationsController < Api::V0x0::AuthenticationsController
       include Api::V0x1::Mixins::CreateMixin
       include Api::V0x1::Mixins::DestroyMixin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     match "/v0/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect(:path => "/#{prefix}/v0.0/%{path}", :only_path => true)
 
     namespace :v0x1, :path => "v0.1" do
+      get "/openapi.json", :to => "root#openapi"
       resources :authentications,         :only => [:create, :destroy, :index, :show, :update]
       resources :containers,              :only => [:index, :show]
       resources :container_groups,        :only => [:index, :show] do

--- a/public/doc/swagger-2-v0.1.0.yaml
+++ b/public/doc/swagger-2-v0.1.0.yaml
@@ -469,6 +469,15 @@ paths:
             "$ref": "#/definitions/Flavor"
         404:
           description: Not found
+  "/openapi.json":
+    get:
+      summary: Return this API document in JSON format
+      operationId: getDocumentation
+      produces:
+      - application/json
+      responses:
+        200:
+          description: The API document for this version of the API
   "/orchestration_stacks":
     get:
       summary: List OrchestrationStacks


### PR DESCRIPTION
The IPP now requires that the api document be available at `/api/v0.1/openapi.json`