### PR TITLE
Fix allowed create/update params for endpoints

### DIFF
--- a/app/controllers/api/v0/endpoints_controller.rb
+++ b/app/controllers/api/v0/endpoints_controller.rb
@@ -14,7 +14,7 @@ module Api
       private
 
       def update_params
-        params.permit(:role, :port, :source_id, :default, :scheme, :host, :path, :id)
+        params.permit(:role, :port, :source_id, :default, :scheme, :host, :path, :verify_ssl, :certificate_authority, :id)
       end
     end
   end

--- a/public/doc/swagger-2-v0.0.1.yaml
+++ b/public/doc/swagger-2-v0.0.1.yaml
@@ -1626,6 +1626,13 @@ definitions:
         type: string
         readOnly: true
         format: uuid
+      verify_ssl:
+        type: boolean
+        example: true
+        description: Should SSL be verified
+      certificate_authority:
+        type: string
+        description: Optional X.509 Certificate Authority
   Flavor:
     type: object
     properties:

--- a/public/doc/swagger-2-v0.1.0.yaml
+++ b/public/doc/swagger-2-v0.1.0.yaml
@@ -1757,6 +1757,13 @@ definitions:
         type: string
         readOnly: true
         format: uuid
+      verify_ssl:
+        type: boolean
+        example: true
+        description: Should SSL be verified
+      certificate_authority:
+        type: string
+        description: Optional X.509 Certificate Authority
   EndpointsCollection:
     type: object
     properties:

--- a/spec/controllers/api/v0x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x0/endpoints_controller_spec.rb
@@ -10,7 +10,20 @@ RSpec.describe Api::V0x0::EndpointsController, :type => :request do
 
   it "post /endpoints creates an Endpoint" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x0_endpoints_url, :params => {:host => "example.com", :source_id => source.id.to_s, :tenant_id => tenant.id.to_s}.to_json)
+    post(
+      api_v0x0_endpoints_url,
+      :params => {
+        :host                  => "example.com",
+        :port                  => "443",
+        :role                  => "default",
+        :path                  => "api",
+        :source_id             => source.id.to_s,
+        :tenant_id             => tenant.id.to_s,
+        :scheme                => "https",
+        :verify_ssl            => true,
+        :certificate_authority => "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----",
+      }.to_json
+    )
 
     endpoint = Endpoint.first
 

--- a/spec/controllers/api/v0x1/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v0x1/endpoints_controller_spec.rb
@@ -11,7 +11,20 @@ RSpec.describe Api::V0x1::EndpointsController, :type => :request do
 
   it "post /endpoints creates an Endpoint" do
     headers = { "CONTENT_TYPE" => "application/json" }
-    post(api_v0x1_endpoints_url, :params => {:host => "example.com", :source_id => source.id.to_s, :tenant_id => tenant.id.to_s}.to_json)
+    post(
+      api_v0x1_endpoints_url,
+      :params => {
+        :host                  => "example.com",
+        :port                  => "443",
+        :role                  => "default",
+        :path                  => "api",
+        :source_id             => source.id.to_s,
+        :tenant_id             => tenant.id.to_s,
+        :scheme                => "https",
+        :verify_ssl            => true,
+        :certificate_authority => "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----",
+      }.to_json
+    )
 
     endpoint = Endpoint.first
 


### PR DESCRIPTION
Endpoints were missing verify_ssl and certificate_authority as allowed
create/update params.