### PR TITLE
Fix undefined raise_unless_primary_instance_exists

### DIFF
--- a/app/controllers/api/v0/availabilities_controller.rb
+++ b/app/controllers/api/v0/availabilities_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V0
     class AvailabilitiesController < ApplicationController
-      include Api::V0x1::Mixins::IndexMixin
+      include Api::V0::Mixins::IndexMixin
     end
   end
 end

--- a/app/controllers/api/v0x1.rb
+++ b/app/controllers/api/v0x1.rb
@@ -10,7 +10,9 @@ module Api
       include Api::V0x1::Mixins::IndexMixin
     end
 
-    class AvailabilitiesController < Api::V0::AvailabilitiesController; end
+    class AvailabilitiesController < Api::V0::AvailabilitiesController
+      include Api::V0x1::Mixins::IndexMixin
+    end
 
     class ContainersController < Api::V0x0::ContainersController
       include Api::V0x1::Mixins::IndexMixin


### PR DESCRIPTION
Fix `NameError: undefined local variable or method 'raise_unless_primary_instance_exists'` when getting a list of availabilities.

Even though the AvailabilitiesController only exists for the v0.1 API it still needs to include the v0::IndexMixin which is where the raise_unless_primary_instance_exists method is defined.

Before:
```
curl http://0.0.0.0:3000/api/v0.1/source_types/1/availabilities
```

```
[----] I, [2019-02-25T14:28:40.265254 #11549:2afb4e6f64a8]  INFO -- : Processing by Api::V0x1::AvailabilitiesController#index as */*
[----] I, [2019-02-25T14:28:40.265339 #11549:2afb4e6f64a8]  INFO -- :   Parameters: {"source_type_id"=>"1"}
[----] I, [2019-02-25T14:28:40.365639 #11549:2afb4e6f64a8]  INFO -- : Completed 500 Internal Server Error in 100ms (ActiveRecord: 0.0ms)


[----] F, [2019-02-25T14:28:40.366064 #11549:2afb4e6f64a8] FATAL -- :   
[----] F, [2019-02-25T14:28:40.406474 #11549:2afb4e6f64a8] FATAL -- : NameError (undefined local variable or method `raise_unless_primary_instance_exists' for #<Api::V0x1::AvailabilitiesController:0x00007fafa83e6980>):
[----] F, [2019-02-25T14:28:40.406608 #11549:2afb4e6f64a8] FATAL -- :   
[----] F, [2019-02-25T14:28:40.406670 #11549:2afb4e6f64a8] FATAL -- : app/controllers/api/v0x1/mixins/index_mixin.rb:6:in `index'
```

After:
```
curl http://0.0.0.0:3000/api/v0.1/source_types/1/availabilities
{"meta":{"count":0},"links":{"first":"/api/v0.1/source_types/1/availabilities?offset=0","last":"/api/v0.1/source_types/1/availabilities?offset=0"},"data":[]}
```

```
[----] I, [2019-02-25T14:29:06.737856 #11669:2ae9480abb60]  INFO -- : Started GET "/api/v0.1/source_types/1/availabilities" for 127.0.0.1 at 2019-02-25 14:29:06 -0500
[----] D, [2019-02-25T14:29:06.780485 #11669:2ae9480abb60] DEBUG -- :    (0.6ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
[----] I, [2019-02-25T14:29:06.863492 #11669:2ae9480abb60]  INFO -- : Processing by Api::V0x1::AvailabilitiesController#index as */*
[----] I, [2019-02-25T14:29:06.863584 #11669:2ae9480abb60]  INFO -- :   Parameters: {"source_type_id"=>"1"}
[----] D, [2019-02-25T14:29:06.872321 #11669:2ae9480abb60] DEBUG -- :   SourceType Load (0.3ms)  SELECT  "source_types".* FROM "source_types" WHERE "source_types"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
[----] D, [2019-02-25T14:29:06.928725 #11669:2ae9480abb60] DEBUG -- :    (0.5ms)  SELECT COUNT(*) FROM "availabilities" WHERE "availabilities"."action" = $1 AND "availabilities"."resource_id" = $2 AND "availabilities"."resource_type" = $3  [["action", "index"], ["resource_id", 1], ["resource_type", "SourceType"]]
[----] D, [2019-02-25T14:29:06.929831 #11669:2ae9480abb60] DEBUG -- :   Availability Load (0.4ms)  SELECT  "availabilities".* FROM "availabilities" WHERE "availabilities"."action" = $1 AND "availabilities"."resource_id" = $2 AND "availabilities"."resource_type" = $3 ORDER BY "availabilities"."id" ASC LIMIT $4 OFFSET $5  [["action", "index"], ["resource_id", 1], ["resource_type", "SourceType"], ["LIMIT", 100], ["OFFSET", 0]]
[----] I, [2019-02-25T14:29:06.930205 #11669:2ae9480abb60]  INFO -- : Completed 200 OK in 67ms (Views: 0.6ms | ActiveRecord: 5.8ms)
```