### PR TITLE
Tasks need to be updatable through the API

### DIFF
--- a/app/controllers/api/v0/tasks_controller.rb
+++ b/app/controllers/api/v0/tasks_controller.rb
@@ -3,6 +3,7 @@ module Api
     class TasksController < ApplicationController
       include Api::V0::Mixins::IndexMixin
       include Api::V0::Mixins::ShowMixin
+      include Api::V0::Mixins::UpdateMixin
     end
   end
 end


### PR DESCRIPTION
The openshift-operations worker is updating tasks through the API, so we
need to include the update mixin in the tasks controller.