### PR TITLE
Don't .to_s nil attributes when serializing

### DIFF
--- a/lib/open_api/serializer.rb
+++ b/lib/open_api/serializer.rb
@@ -9,6 +9,7 @@ module OpenApi
       schema  = Api::Docs[version].definitions[self.class.name]
       attrs   = encryption_filtered.slice(*schema["properties"].keys)
       schema["properties"].keys.each do |name|
+        next if attrs[name].nil?
         attrs[name] = attrs[name].iso8601 if attrs[name].kind_of?(Time)
         attrs[name] = attrs[name].to_s if name.ends_with?("_id") || name == "id"
         attrs[name] = self.public_send(name) if !attrs.key?(name) && !encrypted_columns_set.include?(name)


### PR DESCRIPTION
This led to un-set associations being returned as "" causing the
topological_inventory-client to blow up since "" doesn't pass the format
validation.

e.g.:
```
{
    "description": "Default plan",
    "id": "12605",
    "source_id": "38",
    "source_ref": "83d514ac-fdee-11e8-860c-06945c5af756",
    "source_region_id": "",
    "subscription_id": "",
}
```