### PR TITLE
Update to postgres 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN yum -y install centos-release-scl-rh && \
                    # For checking service status
                    nmap-ncat \
                    # To compile pg gem
-                   rh-postgresql95-postgresql-devel \
-                   rh-postgresql95-postgresql-libs \
+                   rh-postgresql10-postgresql-devel \
+                   rh-postgresql10-postgresql-libs \
                    && \
     yum clean all
 
@@ -19,7 +19,7 @@ ENV RAILS_ROOT $WORKDIR
 WORKDIR $WORKDIR
 
 COPY Gemfile $WORKDIR
-RUN source /opt/rh/rh-postgresql95/enable && \
+RUN source /opt/rh/rh-postgresql10/enable && \
     echo "gem: --no-document" > ~/.gemrc && \
     gem install bundler --conservative --without development:test && \
     bundle install --jobs 8 --retry 3 && \

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -30,5 +30,5 @@ write_encryption_key
 # Wait for postgres to be ready
 check_svc_status $DATABASE_HOST $DATABASE_PORT
 
-bundle exec rake db:create db:migrate db:seed
+bundle exec rake db:migrate db:seed
 bundle exec rails server


### PR DESCRIPTION
Use the postgres 10 packages for building the PG gem and don't try to create the database on first boot.

The image we're using will create the database that we pass in an environment variable and doesn't give the user we pass `CREATEDB` permission by default.

It turns out we don't really need those permissions so we can drop our image entirely and just use the image provided.