### PR TITLE
Fix tests failing due to changed metadata in paginated responses

### DIFF
--- a/spec/controllers/api/v0x1/mixins/index_mixin_spec.rb
+++ b/spec/controllers/api/v0x1/mixins/index_mixin_spec.rb
@@ -37,7 +37,7 @@ describe Api::V0x1::Mixins::IndexMixin do
         get(api_v0x1_sources_url)
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["meta"]).to eq("count" => 2)
+        expect(response.parsed_body["meta"]).to eq("count" => 2, "limit" => 100, "offset" => 0)
       end
     end
   end

--- a/spec/support/paginated_response_matcher.rb
+++ b/spec/support/paginated_response_matcher.rb
@@ -1,6 +1,10 @@
 def paginated_response(count, data)
   {
-    "meta"  => {"count" => count},
+    "meta"  => {
+      "count" => count,
+      "limit" => kind_of(Integer),
+      "offset" => kind_of(Integer)
+    },
     "links" => a_hash_including(
       "first" => a_string_including("?offset=0"),
       "last"  => a_string_including("?offset=")


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-api-common/pull/35
This should probably move to manageiq-api-common (and be a real matcher), but let's get things green first