### PR TITLE
Task created by service_plans had invalid status

### DIFF
--- a/app/controllers/api/v0/service_plans_controller.rb
+++ b/app/controllers/api/v0/service_plans_controller.rb
@@ -6,12 +6,12 @@ module Api
 
       def order
         service_plan = model.find(params_for_order[:service_plan_id].to_i)
-        task = Task.create!(:tenant => service_plan.tenant, :status => "started")
+        task = Task.create!(:tenant => service_plan.tenant, :state => "pending", :status => "ok")
 
         messaging_client.publish_message(
           :service => "platform.topological-inventory.operations-openshift",
           :message => "ServicePlan.order",
-          :payload => {:task_id => task.id, :service_plan_id => service_plan.id, :order_params => params_for_order}
+          :payload => {:task_id => task.id.to_s, :service_plan_id => service_plan.id.to_s, :order_params => params_for_order}
         )
 
         render :json => {:task_id => task.id}

--- a/spec/controllers/api/v0x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x0/service_plans_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Api::V0x0::ServicePlansController, :type => :request do
         expect(client).to receive(:publish_message).with(
           :service => "platform.topological-inventory.operations-openshift",
           :message => "ServicePlan.order",
-          :payload => {:task_id => kind_of(Numeric), :service_plan_id => service_plan.id, :order_params => payload}
+          :payload => {:task_id => kind_of(String), :service_plan_id => service_plan.id.to_s, :order_params => payload}
         )
 
         post "/api/v0.0/service_plans/#{service_plan.id}/order", :params => payload

--- a/spec/controllers/api/v0x1/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v0x1/service_plans_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Api::V0x1::ServicePlansController, :type => :request do
         expect(client).to receive(:publish_message).with(
           :service => "platform.topological-inventory.operations-openshift",
           :message => "ServicePlan.order",
-          :payload => {:task_id => kind_of(Numeric), :service_plan_id => service_plan.id, :order_params => payload}
+          :payload => {:task_id => kind_of(String), :service_plan_id => service_plan.id.to_s, :order_params => payload}
         )
 
         post "/api/v0.1/service_plans/#{service_plan.id}/order", :params => payload

--- a/spec/controllers/api/v0x1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v0x1/tasks_controller_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Api::V0x1::TasksController, :type => :request do
   let(:tenant) { Tenant.create! }
 
   it "patch /tasks/:id updates a Task" do
-    task = Task.create!(:status => "started", :context => "context1", :tenant => tenant)
+    task = Task.create!(:state => "running", :status => "ok", :context => "context1", :tenant => tenant)
 
-    patch(api_v0x1_task_url(task.id), :params => {:status => "completed", :context => "context2"}.to_json)
+    patch(api_v0x1_task_url(task.id), :params => {:state => "completed", :status => "ok", :context => "context2"}.to_json)
 
-    expect(task.reload.status).to eq("completed")
+    expect(task.reload.state).to eq("completed")
+    expect(task.reload.status).to eq("ok")
     expect(task.context).to eq("context2")
 
     expect(response.status).to eq(204)


### PR DESCRIPTION
Fix the state/status for tasks created by service_plans_controller, also `.to_s` the IDs passed in the queue payload so the other side doesn't have to.