### PR TITLE
Fix for TPINVTRY-224 - Inconsistent swagger response codes for resource updates

### DIFF
--- a/lib/tasks/swagger_generate.rake
+++ b/lib/tasks/swagger_generate.rake
@@ -274,6 +274,7 @@ class SwaggerGenerator
       ],
       "responses" => {
         204 => {"description" => "Updated, no content"},
+        400 => {"description" => "Bad request"},
         404 => {"description" => "Not found"}
       }
     }

--- a/public/doc/swagger-2-v0.1.0.yaml
+++ b/public/doc/swagger-2-v0.1.0.yaml
@@ -86,6 +86,8 @@ paths:
       responses:
         204:
           description: Updated, no content
+        400:
+          description: Bad request
         404:
           description: Not found
     delete:
@@ -503,6 +505,8 @@ paths:
       responses:
         204:
           description: Updated, no content
+        400:
+          description: Bad request
         404:
           description: Not found
     delete:
@@ -975,6 +979,8 @@ paths:
       responses:
         204:
           description: Updated, no content
+        400:
+          description: Bad request
         404:
           description: Not found
     delete:
@@ -1423,6 +1429,8 @@ paths:
       responses:
         204:
           description: Updated, no content
+        400:
+          description: Bad request
         404:
           description: Not found
   "/vms":


### PR DESCRIPTION

This fixes https://projects.engineering.redhat.com/browse/TPINVTRY-224

The 400 is actually the proper return code for trying to update read-only attributes,
i.e. a Bad Request. We generate the 400's properly as we catch
the ActionController::UnpermittedParameters error.

Fix was to update the swagger_generate.rake script to include a 400 response
code for collection updates.  This is effectively reflected for
the authentications, endpoints, sources and tasks collections.