### PR TITLE
Fix for TPINVTRY-230 - Wrong return code for get queries with text ID

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -133,7 +133,7 @@ class ApplicationController < ActionController::API
   end
 
   def request_path_parts
-    @request_path_parts ||= request_path.match(/\/(?<full_version_string>v\d+.\d+)\/(?<primary_collection_name>\w+)\/?(?<primary_collection_id>\d+)?\/?(?<subcollection_name>\w+)?/)&.named_captures || {}
+    @request_path_parts ||= request_path.match(/\/(?<full_version_string>v\d+.\d+)\/(?<primary_collection_name>\w+)\/?(?<primary_collection_id>[^\/]+)?\/?(?<subcollection_name>\w+)?/)&.named_captures || {}
   end
 
   def subcollection?

--- a/spec/requests/api/v0.1/shared_examples_for_index.rb
+++ b/spec/requests/api/v0.1/shared_examples_for_index.rb
@@ -52,6 +52,15 @@ RSpec.shared_examples "test_index_and_subcollections" do |primary_collection, su
                               :parsed_body => ""
                             )
       end
+
+      it "failure: with an invalid non-numeric id" do
+        get(instance_path("non_numeric_id"))
+
+        expect(response).to have_attributes(
+                              :status      => 404,
+                              :parsed_body => ""
+                            )
+      end
     end
   end
 
@@ -86,6 +95,15 @@ RSpec.shared_examples "test_index_and_subcollections" do |primary_collection, su
             expect(response).to have_attributes(
                                   :status      => 404,
                                   :parsed_body => {"errors" => [{"detail" => "Couldn't find #{primary_collection.to_s.singularize.camelize} with 'id'=#{missing_id}", "status" => 404}]}
+                                )
+          end
+
+          it "failure: with an invalid non-numeric id" do
+            get(subcollection_path("non_numeric_id"))
+
+            expect(response).to have_attributes(
+                                  :status      => 404,
+                                  :parsed_body => {"errors" => [{"detail" => /Couldn't find #{primary_collection.to_s.singularize.camelize}/, "status" => 404}]}
                                 )
           end
         end


### PR DESCRIPTION
    This fixes https://projects.engineering.redhat.com/browse/TPINVTRY-230

    The issue at hand is how we parsed the request path parts, since we explicitly
    looking for numeric id's, that part of the matching and related subcollection
    were returning nil, this essentially causing an empty result with the bogus links.

    The fix was to parse any of the characters up until the / separator of the path parts.
    This will give us the appropriately parsed collection resource id and subcollection names
    which will result in the 404 we're looking for.

    Updated tests to include non-numeric id fetches for collections resources
    and related subcollections.