### PR TITLE
API Filtering

### DIFF
--- a/app/controllers/api/v0x1/mixins/index_mixin.rb
+++ b/app/controllers/api/v0x1/mixins/index_mixin.rb
@@ -5,7 +5,7 @@ module Api
         def index
           raise_unless_primary_instance_exists
           render json: ManageIQ::API::Common::PaginatedResponse.new(
-            base_query: scoped(model.where(params_for_list)),
+            base_query: scoped(filtered.where(params_for_list)),
             request: request,
             limit: pagination_limit,
             offset: pagination_offset

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,18 +2,18 @@ class ApplicationController < ActionController::API
   ActionController::Parameters.action_on_unpermitted_parameters = :raise
 
   rescue_from ActionController::UnpermittedParameters do |exception|
-    error_document = TopologicalInventory::Api::ErrorDocument.new.add(400, exception.message)
-    render :json => error_document, :status => error_document.status
+    error_document = TopologicalInventory::Api::ErrorDocument.new.add(exception.message)
+    render :json => error_document.to_h, :status => error_document.status
   end
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
     error_document = TopologicalInventory::Api::ErrorDocument.new.add(404, exception.message)
-    render :json => error_document, :status => :not_found
+    render :json => error_document.to_h, :status => :not_found
   end
 
   rescue_from TopologicalInventory::Api::BodyParseError do |exception|
-    error_document = TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
-    render :json => error_document, :status => error_document.status
+    error_document = TopologicalInventory::Api::ErrorDocument.new.add("Failed to parse POST body, expected JSON")
+    render :json => error_document.to_h, :status => error_document.status
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::API
     render :json => error_document.to_h, :status => :not_found
   end
 
+  rescue_from ApplicationController::Filter::Error do |exception|
+    render :json => exception.error_document.to_h, :status => exception.error_document.status
+  end
+
   rescue_from TopologicalInventory::Api::BodyParseError do |exception|
     error_document = TopologicalInventory::Api::ErrorDocument.new.add("Failed to parse POST body, expected JSON")
     render :json => error_document.to_h, :status => error_document.status
@@ -53,7 +57,7 @@ class ApplicationController < ActionController::API
 
   def safe_params_for_list
     # :limit & :offset can be passed in for pagination purposes, but shouldn't show up as params for filtering purposes
-    @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params)
+    @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params, :filter => {})
   end
 
   def permitted_params
@@ -114,6 +118,10 @@ class ApplicationController < ActionController::API
 
   def all_attributes_for_index
     api_doc_definition.all_attributes + [subcollection_foreign_key_using_through_relation]
+  end
+
+  def filtered
+    ApplicationController::Filter.new(model, safe_params_for_list[:filter], api_doc_definition).apply
   end
 
   def pagination_limit

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1,0 +1,152 @@
+class ApplicationController
+  class Filter
+    INTEGER_COMPARISON_KEYWORDS = ["eq", "gt", "gte", "lt", "lte", "nil", "not_nil"].freeze
+    STRING_COMPARISON_KEYWORDS  = ["contains", "eq", "starts_with", "ends_with", "nil", "not_nil"].freeze
+
+    attr_reader :apply, :api_doc_definition
+
+    def initialize(model, raw_filter, api_doc_definition)
+      self.query          = model
+      @raw_filter         = raw_filter
+      @api_doc_definition = api_doc_definition
+    end
+
+    def apply
+      return query if @raw_filter.blank?
+      @raw_filter.each do |k, v|
+        with_attribute_for_key(k) do |attribute|
+          if attribute["type"] == "string"
+            type = determine_string_attribute_type(attribute)
+            send(type, k, v)
+          else
+            errors.add("unsupported attribute type for: #{k}")
+          end
+        end
+      end
+
+      raise ApplicationController::Filter::Error.new(:error_document => errors) unless errors.blank?
+      query
+    end
+
+    private
+
+    attr_accessor :query
+
+    class Error < ArgumentError
+      attr_reader :error_document
+
+      def initialize(attrs)
+        @error_document = attrs[:error_document]
+      end
+    end
+
+    def with_attribute_for_key(key)
+      attribute = api_doc_definition.properties[key.to_s]
+      attribute ? yield(attribute) : errors.add("found unpermitted parameter: #{key}")
+    end
+
+    def determine_string_attribute_type(attribute)
+      return :timestamp if attribute["format"] == "date-time"
+      return :integer if attribute["pattern"] == /^\d+$/
+      :string
+    end
+
+    def errors
+      @errors ||= TopologicalInventory::Api::ErrorDocument.new
+    end
+
+    def string(k, val)
+      if val.kind_of?(ActionController::Parameters)
+        val.each do |comparator, value|
+          add_filter(comparator, STRING_COMPARISON_KEYWORDS, k, value)
+        end
+      else
+        add_filter("eq", STRING_COMPARISON_KEYWORDS, k, val)
+      end
+    end
+
+    def add_filter(requested_comparator, allowed_comparators, key, value)
+      type = with_attribute_for_key(key) { |attribute| determine_string_attribute_type(attribute) }
+
+      if requested_comparator.in?(["nil", "not_nil"])
+        send("comparator_#{requested_comparator}", key, value)
+      elsif requested_comparator.in?(allowed_comparators)
+        value = parse_datetime(value) if type == :datetime
+        return if value.nil?
+        send("comparator_#{requested_comparator}", key, value)
+      else
+        errors.add("unsupported #{type} comparator: #{requested_comparator}")
+      end
+    end
+
+    def timestamp(k, val)
+      if val.kind_of?(ActionController::Parameters)
+        val.each do |comparator, value|
+          add_filter(comparator, INTEGER_COMPARISON_KEYWORDS, k, value)
+        end
+      else
+        add_filter("eq", INTEGER_COMPARISON_KEYWORDS, k, val)
+      end
+    end
+
+    def parse_datetime(value)
+      return value.collect { |i| parse_datetime(i) } if value.kind_of?(Array)
+
+      DateTime.parse(value)
+    rescue ArgumentError
+      errors.add("invalid timestamp: #{value}")
+      return nil
+    end
+
+    def integer(k, val)
+      if val.kind_of?(ActionController::Parameters)
+        val.each do |comparator, value|
+          add_filter(comparator, INTEGER_COMPARISON_KEYWORDS, k, value)
+        end
+      else
+        add_filter("eq", INTEGER_COMPARISON_KEYWORDS, k, val)
+      end
+    end
+
+    def comparator_contains(key, value)
+      return value.each { |v| comparator_contains(key, v) } if value.kind_of?(Array)
+      self.query = query.where("#{key} LIKE ?", "%#{value}%")
+    end
+
+    def comparator_starts_with(key, value)
+      self.query = query.where("#{key} LIKE ?", "#{value}%")
+    end
+
+    def comparator_ends_with(key, value)
+      self.query = query.where("#{key} LIKE ?", "%#{value}")
+    end
+
+    def comparator_eq(key, value)
+      self.query = query.where(key => value)
+    end
+
+    def comparator_gt(key, value)
+      self.query = query.where("#{key} > ?", value)
+    end
+
+    def comparator_gte(key, value)
+      self.query = query.where("#{key} >= ?", value)
+    end
+
+    def comparator_lt(key, value)
+      self.query = query.where("#{key} < ?", value)
+    end
+
+    def comparator_lte(key, value)
+      self.query = query.where("#{key} <= ?", value)
+    end
+
+    def comparator_nil(key, _value = nil)
+      self.query = query.where(key => nil)
+    end
+
+    def comparator_not_nil(key, _value = nil)
+      self.query = query.where.not(key => nil)
+    end
+  end
+end

--- a/lib/topological_inventory/api/error_document.rb
+++ b/lib/topological_inventory/api/error_document.rb
@@ -1,18 +1,26 @@
 module TopologicalInventory
   module Api
-    class ErrorDocument < Hash
-      def initialize
-        self["errors"] = []
+    class ErrorDocument
+      def add(status = 400, message)
+        @status = status
+        errors << {"status" => status, "detail" => message}
+        self
       end
 
-      def add(status, message)
-        @status = status
-        self["errors"] << {"status" => status, "detail" => message}
-        self
+      def errors
+        @errors ||= []
       end
 
       def status
         @status
+      end
+
+      def blank?
+        errors.blank?
+      end
+
+      def to_h
+        {"errors" => errors}
       end
     end
   end

--- a/spec/requests/api/v0.0/authentications_spec.rb
+++ b/spec/requests/api/v0.0/authentications_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe("v0.0 - Authentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON").to_h
         )
       end
 
@@ -53,7 +53,7 @@ RSpec.describe("v0.0 - Authentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
     end

--- a/spec/requests/api/v0.0/source_types_spec.rb
+++ b/spec/requests/api/v0.0/source_types_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe("v0.0 - SourceTypes") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON").to_h
         )
       end
 
@@ -52,7 +52,7 @@ RSpec.describe("v0.0 - SourceTypes") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
     end

--- a/spec/requests/api/v0.0/sources_spec.rb
+++ b/spec/requests/api/v0.0/sources_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe("v0.0 - Sources") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON").to_h
         )
       end
 
@@ -54,7 +54,7 @@ RSpec.describe("v0.0 - Sources") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
     end

--- a/spec/requests/api/v0.1/authentications_spec.rb
+++ b/spec/requests/api/v0.1/authentications_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe("v0.1 - Authentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON").to_h
         )
       end
 
@@ -53,7 +53,7 @@ RSpec.describe("v0.1 - Authentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
     end

--- a/spec/requests/api/v0.1/source_types_spec.rb
+++ b/spec/requests/api/v0.1/source_types_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe("v0.1 - SourceTypes") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON").to_h
         )
       end
 
@@ -38,7 +38,7 @@ RSpec.describe("v0.1 - SourceTypes") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
     end

--- a/spec/requests/api/v0.1/sources_spec.rb
+++ b/spec/requests/api/v0.1/sources_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe("v0.0 - Sources") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "Failed to parse POST body, expected JSON").to_h
         )
       end
 
@@ -55,7 +55,7 @@ RSpec.describe("v0.0 - Sources") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa")
+          :parsed_body => TopologicalInventory::Api::ErrorDocument.new.add(400, "found unpermitted parameter: :aaa").to_h
         )
       end
     end

--- a/spec/requests/application_controller/filter_spec.rb
+++ b/spec/requests/application_controller/filter_spec.rb
@@ -1,0 +1,120 @@
+RSpec.describe("ApplicationController::Filter") do
+  let(:tenant) { Tenant.create! }
+
+  def create_task(attrs = {})
+    Task.create!(
+      attrs.merge(
+        :state  => "pending",
+        :status => "ok",
+        :tenant => tenant,
+      )
+    )
+  end
+
+  def expect_failure(query, *errors)
+    get("/api/v0.1/tasks?#{query}")
+
+    expect(response).to have_attributes(
+      :parsed_body => {
+        "errors" => errors.collect { |e| {"detail" => e, "status" => 400} }
+      },
+      :status      => 400,
+    )
+  end
+
+  def expect_success(query, *results)
+    get("/api/v0.1/tasks?#{query}")
+
+    expect(response).to have_attributes(
+      :parsed_body => paginated_response(results.length, results.collect { |i| a_hash_including("id" => i.id.to_s) }),
+      :status      => 200,
+    )
+  end
+
+  context "strings" do
+    let!(:task_1) { create_task(:name => "aaa") }
+    let!(:task_2) { create_task(:name => "bbb") }
+    let!(:task_3) { create_task(:name => "abc") }
+    let!(:task_4) { create_task }
+
+    it("key:eq single without 'eq' key")          { expect_success("filter[name]=#{task_1.name}", task_1) }
+    it("key:eq array of values without 'eq' key") { expect_success("filter[name][]=#{task_1.name}&filter[name][]=#{task_2.name}", task_1, task_2) }
+    it("key:eq single with 'eq' key")             { expect_success("filter[name][eq]=#{task_1.name}", task_1) }
+    it("key:eq array of values with 'eq' key")    { expect_success("filter[name][eq][]=#{task_1.name}&filter[name][eq][]=#{task_2.name}", task_1, task_2) }
+
+    it("key:contains single")                     { expect_success("filter[name][contains]=a", task_1, task_3) }
+    it("key:contains array")                      { expect_success("filter[name][contains][]=a&filter[name][contains][]=b", task_3) }
+
+    it("key:ends_with")                           { expect_success("filter[name][ends_with]=a", task_1) }
+    it("key:starts_with")                         { expect_success("filter[name][starts_with]=b", task_2) }
+    it("key:nil")                                 { expect_success("filter[name][nil]", task_4) }
+    it("key:not_nil")                             { expect_success("filter[name][not_nil]", task_1, task_2, task_3) }
+  end
+
+  context "integers" do
+    let!(:task_1) { create_task }
+    let!(:task_2) { create_task }
+    let!(:task_3) { create_task }
+    let!(:task_4) { create_task }
+
+    it("key:eq single without 'eq' key")          { expect_success("filter[id]=#{task_1.id}", task_1) }
+    it("key:eq array of values without 'eq' key") { expect_success("filter[id][]=#{task_1.id}&filter[id][]=#{task_2.id}", task_1, task_2) }
+    it("single with 'eq' key")                    { expect_success("filter[id][eq]=#{task_1.id}", task_1) }
+    it("array of values with 'eq' key")           { expect_success("filter[id][eq][]=#{task_1.id}&filter[id][eq][]=#{task_2.id}", task_1, task_2) }
+
+    it("key:gt")                                  { expect_success("filter[id][gt]=#{task_2.id}", task_3, task_4) }
+    it("key:gte")                                 { expect_success("filter[id][gte]=#{task_2.id}", task_2, task_3, task_4) }
+    it("key:lt")                                  { expect_success("filter[id][lt]=#{task_3.id}", task_1, task_2) }
+    it("key:lte")                                 { expect_success("filter[id][lte]=#{task_3.id}", task_1, task_2, task_3) }
+  end
+
+  context "timestamps" do
+    let!(:task_1) { create_task }
+    let!(:task_2) { create_task(:completed_at => Time.parse("2019-03-06T16:15Z").utc) }
+    let!(:task_3) { create_task(:completed_at => Time.parse("2019-03-06T16:17Z").utc) }
+    let!(:task_4) { create_task(:completed_at => Time.parse("2019-03-07T00:01Z").utc) }
+
+    it("key:eq y-m-dTh:m:s single without 'eq' key") { expect_success("filter[completed_at]=2019-03-06T16:17:00", task_3) }
+    it("key:eq y-m-dTh:m single without 'eq' key")   { expect_success("filter[completed_at]=2019-03-06T16:17", task_3) }
+    it("key:eq y-m-dTh:m:s single with 'eq' key")    { expect_success("filter[completed_at][eq]=2019-03-06T16:17:00", task_3) }
+    it("key:eq y-m-dTh:m single with 'eq' key")      { expect_success("filter[completed_at][eq]=2019-03-06T16:17", task_3) }
+
+    it("key:eq y-m-dTh:m:s array without 'eq' key") { expect_success("filter[completed_at][]=2019-03-06T16:17:00&filter[completed_at][]=2019-03-06T16:15:00", task_2, task_3) }
+    it("key:eq y-m-dTh:m array without 'eq' key")   { expect_success("filter[completed_at][]=2019-03-06T16:17&filter[completed_at][]=2019-03-06T16:15", task_2, task_3) }
+    it("key:eq y-m-dTh:m:s array with 'eq' key")    { expect_success("filter[completed_at][eq][]=2019-03-06T16:17:00&filter[completed_at][eq][]=2019-03-06T16:15:00", task_2, task_3) }
+    it("key:eq y-m-dTh:m array with 'eq' key")      { expect_success("filter[completed_at][eq][]=2019-03-06T16:17&filter[completed_at][eq][]=2019-03-06T16:15", task_2, task_3) }
+
+    it("key:gt y-m-dTh:m:s") { expect_success("filter[completed_at][gt]=2019-03-06T16:16:05", task_3, task_4) }
+    it("key:gt y-m-dTh:m")   { expect_success("filter[completed_at][gt]=2019-03-06T16:16", task_3, task_4) }
+    it("key:gt y-m-d")       { expect_success("filter[completed_at][gt]=2019-03-06", task_2, task_3, task_4) }
+
+    it("key:lt y-m-dTh:m:s") { expect_success("filter[completed_at][lt]=2019-03-06T16:17:05", task_2, task_3) }
+    it("key:lt y-m-dTh:m")   { expect_success("filter[completed_at][lt]=2019-03-06T16:17", task_2) }
+    it("key:lt y-m-d")       { expect_success("filter[completed_at][lt]=2019-03-06") }
+
+    it("key:nil")            { expect_success("filter[completed_at][nil]", task_1) }
+    it("key:not_nil")        { expect_success("filter[completed_at][not_nil]", task_2, task_3, task_4) }
+  end
+
+  context "error cases" do
+    it("empty filter")      { expect_failure("filter", "found unpermitted parameter: :filter") }
+    it("unknown attribute") { expect_failure("filter[xxx]", "found unpermitted parameter: xxx") }
+
+    context "unsupported comparator" do
+      it("on an integer")  { expect_failure("filter[id][xxx]=4", "unsupported integer comparator: xxx") }
+      it("on a string")    { expect_failure("filter[name][xxx]=4", "unsupported string comparator: xxx") }
+      it("on a timestamp") { expect_failure("filter[created_at][xxx]=4", "unsupported timestamp comparator: xxx") }
+    end
+
+    it "unsupported attribute type" do
+      source_type = SourceType.create!(:name => "a", :vendor => "a", :product_name => "a")
+      source = Source.create!(:source_type => source_type, :tenant => tenant, :name => "a")
+      Vm.create!(:source => source, :tenant => tenant, :source_ref => "a")
+
+      get("/api/v0.1/vms?filter[mac_addresses]=a")
+
+      expect(response.status).to eq(400)
+      expect(response.parsed_body["errors"]).to eq([{"detail"=>"unsupported attribute type for: mac_addresses", "status"=>400}])
+    end
+  end
+end

--- a/spec/support/paginated_response_matcher.rb
+++ b/spec/support/paginated_response_matcher.rb
@@ -6,8 +6,8 @@ def paginated_response(count, data)
       "offset" => kind_of(Integer)
     },
     "links" => a_hash_including(
-      "first" => a_string_including("?offset=0"),
-      "last"  => a_string_including("?offset=")
+      "first" => a_string_including("offset=0"),
+      "last"  => a_string_including("offset=")
     ),
     "data"  => data
   }


### PR DESCRIPTION
- Add some basic filtering operations for strings, integers and datetimes.  
- Allow for bulk query when the `eq` comparators are used with an array of values.

cc @abellotti 