### PR TITLE
Add route for service offering icon with right image content type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'json-schema',        '~> 2.8'
 gem 'manageiq-loggers',   '~> 0.1'
 gem 'manageiq-messaging', '~> 0.1.2', :require => false
 gem 'manageiq-password',  '~> 0.2', ">= 0.2.1"
+gem 'mimemagic',          '~> 0.3.3'
 gem 'pg',                 '~> 1.0', :require => false
 gem 'puma',               '~> 3.0'
 gem 'rack-cors',          '>= 0.4.1'

--- a/app/controllers/api/v0/service_offering_icons_controller.rb
+++ b/app/controllers/api/v0/service_offering_icons_controller.rb
@@ -4,6 +4,16 @@ module Api
       include Api::V0::Mixins::IndexMixin
       include Api::V0::Mixins::ShowMixin
 
+      def icon_data
+        service_offering_icon = model.find(params[:service_offering_icon_id].to_i)
+
+        send_data(service_offering_icon.data, 
+          :type         => MimeMagic.by_magic(service_offering_icon.data).type,
+          :disposition  => 'inline')
+      rescue ActiveRecord::RecordNotFound
+        head :not_found
+      end
+
       private
 
       def model

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,9 @@ Rails.application.routes.draw do
       end
       resources :flavors,                 :only => [:index, :show]
       resources :service_instances,       :only => [:index, :show]
-      resources :service_offering_icons,  :only => [:index, :show]
+      resources :service_offering_icons,  :only => [:index, :show] do
+        get "icon_data", :to => "service_offering_icons#icon_data"
+      end
       resources :service_offerings,       :only => [:index, :show] do
         resources :service_instances, :only => [:index]
         resources :service_plans,     :only => [:index]

--- a/public/doc/swagger-2-v0.1.0.yaml
+++ b/public/doc/swagger-2-v0.1.0.yaml
@@ -718,6 +718,22 @@ paths:
             "$ref": "#/definitions/ServiceOfferingIcon"
         404:
           description: Not found
+  "/service_offering_icons/{id}/icon_data":
+    get:
+      summary: Show an existing ServiceOfferingIcon
+      operationId: showServiceOfferingIcon
+      description: Returns a ServiceOfferingIcon object
+      produces:
+      - image/*
+      parameters:
+      - "$ref": "#/parameters/ID"
+      responses:
+        200:
+          description: ServiceOfferingIcon info
+          schema:
+            type: string
+        404:
+          description: Not found
   "/service_offerings":
     get:
       summary: List ServiceOfferings

--- a/spec/requests/api/v0.1/service_offering_icon_spec.rb
+++ b/spec/requests/api/v0.1/service_offering_icon_spec.rb
@@ -4,12 +4,18 @@ RSpec.describe("v0.1 - ServiceOfferingIcon") do
   let(:source) { Source.create!(:name => "name", :source_type => source_type, :tenant => tenant) }
   let(:source_type) { SourceType.create!(:vendor => "vendor", :product_name => "product_name", :name => "name") }
   let(:tenant) { Tenant.create! }
+  let(:data) { '<svg width=\"580\" height=\"400\" xmlns=\"http://www.w3.org/2000/svg\"> <!-- Created with Method Draw -'\
+    'http://github.com/duopixel/Method-Draw/ --> <g>  <title>background</title>  <rect fill=\"#ff0000\" '\
+    'id=\"canvas_background\" height=\"402\" width=\"582\" y=\"-1\" x=\"-1\"/>  <g display=\"none\" overflow=\"visible\"'\
+    ' y=\"0\" x=\"0\" height=\"100%\" width=\"100%\" id=\"canvasGrid\">   <rect fill=\"url(#gridpattern)\" '\
+    'stroke-width=\"0\" y=\"0\" x=\"0\" height=\"100%\" width=\"100%\"/>  </g> </g> <g>  <title>Layer 1</title> </g></svg>' }
 
   let(:attributes) do
     {
       "source_id"            => source.id.to_s,
       "tenant_id"            => tenant.id.to_s,
-      "source_ref"           => SecureRandom.uuid
+      "source_ref"           => SecureRandom.uuid,
+      "data"                 => data
     }
   end
 
@@ -18,4 +24,50 @@ RSpec.describe("v0.1 - ServiceOfferingIcon") do
     "service_offering_icons",
     [],
   )
+
+  describe("/api/v0.1/service_offering_icons/:id/icon_data") do
+    let(:primary_collection) { "service_offering_icons" }
+    let(:subcollection) { "icon_data" }
+    let(:collection_path) { "/api/v0.1/#{primary_collection}" }
+
+    def subcollection_path(id)
+      File.join(collection_path, id.to_s, subcollection)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = primary_collection.to_s.singularize.camelize.constantize.create!(attributes)
+
+        get(subcollection_path(instance.id))
+
+        expect(response).to have_attributes(
+                              :status       => 200,
+                              :parsed_body  => data,
+                              :content_type => "image/svg+xml"
+                              )
+      end
+
+      it "failure: with an invalid id" do
+        instance   = primary_collection.to_s.singularize.camelize.constantize.create!(attributes)
+        missing_id = (instance.id * 1000)
+        expect(primary_collection.to_s.singularize.camelize.constantize.exists?(missing_id)).to eq(false)
+
+        get(subcollection_path(missing_id))
+
+        expect(response).to have_attributes(
+                              :status      => 404,
+                              :parsed_body => ""
+                            )
+      end
+
+      it "failure: with an invalid non-numeric id" do
+        get(subcollection_path("non_numeric_id"))
+
+        expect(response).to have_attributes(
+                              :status      => 404,
+                              :parsed_body => ""
+                            )
+      end
+    end
+  end
 end


### PR DESCRIPTION
With this change we can serve images directly and use classic image tag on client.
```
<img src="http://localhost:3000/api/v0.1/service_offering_icons/2/icon_data" />
```

![Screenshot from 2019-03-21 17-51-39](https://user-images.githubusercontent.com/22619452/54769739-23749800-4c02-11e9-983f-fbe2ffb9a0f8.png)

cc @skateman
