### PR TITLE
Change datatype of create_json_schema to object

### DIFF
--- a/public/doc/swagger-2-v0.1.0.yaml
+++ b/public/doc/swagger-2-v0.1.0.yaml
@@ -2601,7 +2601,7 @@ definitions:
         type: string
       create_json_schema:
         readOnly: true
-        type: string
+        type: object
       created_at:
         format: date-time
         readOnly: true


### PR DESCRIPTION
The for ServicePlan object the attribute create_json_schema is a hash and should have a datatype of object. It is currently being marked as a string which causes deserialization issues on the client side.