### PR TITLE
Remove a lot of extra rescues for record not found

### DIFF
--- a/app/controllers/api/v0/mixins/destroy_mixin.rb
+++ b/app/controllers/api/v0/mixins/destroy_mixin.rb
@@ -5,8 +5,6 @@ module Api
         def destroy
           model.destroy(params.require(:id))
           head :no_content
-        rescue ActiveRecord::RecordNotFound
-          head :not_found
         end
       end
     end

--- a/app/controllers/api/v0/mixins/show_mixin.rb
+++ b/app/controllers/api/v0/mixins/show_mixin.rb
@@ -4,8 +4,6 @@ module Api
       module ShowMixin
         def show
           render json: model.find(params.require(:id))
-        rescue ActiveRecord::RecordNotFound
-          head :not_found
         end
       end
     end

--- a/app/controllers/api/v0/mixins/update_mixin.rb
+++ b/app/controllers/api/v0/mixins/update_mixin.rb
@@ -5,8 +5,6 @@ module Api
         def update
           model.update(params.require(:id), params_for_update)
           head :no_content
-        rescue ActiveRecord::RecordNotFound
-          head :not_found
         end
       end
     end

--- a/app/controllers/api/v0/service_offering_icons_controller.rb
+++ b/app/controllers/api/v0/service_offering_icons_controller.rb
@@ -5,13 +5,12 @@ module Api
       include Api::V0::Mixins::ShowMixin
 
       def icon_data
+        raise_unless_primary_instance_exists
         service_offering_icon = model.find(params[:service_offering_icon_id].to_i)
 
         send_data(service_offering_icon.data, 
           :type         => MimeMagic.by_magic(service_offering_icon.data).type,
           :disposition  => 'inline')
-      rescue ActiveRecord::RecordNotFound
-        head :not_found
       end
 
       private

--- a/app/controllers/api/v0x1/tasks_controller.rb
+++ b/app/controllers/api/v0x1/tasks_controller.rb
@@ -13,8 +13,6 @@ module Api
         )
 
         head :no_content
-      rescue ActiveRecord::RecordNotFound
-        head :not_found
       end
     end
   end

--- a/app/controllers/internal/v0/authentications_controller.rb
+++ b/app/controllers/internal/v0/authentications_controller.rb
@@ -4,8 +4,6 @@ module Internal
       def show
         record = model.find(params_for_show[:id])
         render json: record.as_json(:prefixes => [request.path]).merge(encrypted_attributes(record))
-      rescue ActiveRecord::RecordNotFound
-        head :not_found
       end
 
       private

--- a/spec/requests/api/v0.0/authentications_spec.rb
+++ b/spec/requests/api/v0.0/authentications_spec.rb
@@ -79,11 +79,12 @@ RSpec.describe("v0.0 - Authentications") do
       it "failure: with an invalid id" do
         instance = Authentication.create!(attributes)
 
-        get(instance_path(instance.id * 1000))
+        missing_id = instance.id * 1000
+        get(instance_path(missing_id))
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find Authentication with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
     end

--- a/spec/requests/api/v0.0/container_groups_spec.rb
+++ b/spec/requests/api/v0.0/container_groups_spec.rb
@@ -51,11 +51,12 @@ RSpec.describe("v0.0 - ContainerGroups") do
       it "failure: with an invalid id" do
         instance = ContainerGroup.create!(attributes)
 
-        get(instance_path(instance.id * 1000))
+        missing_id = instance.id * 1000
+        get(instance_path(missing_id))
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find ContainerGroup with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
     end

--- a/spec/requests/api/v0.0/containers_spec.rb
+++ b/spec/requests/api/v0.0/containers_spec.rb
@@ -53,11 +53,12 @@ RSpec.describe("v0.0 - Containers") do
       it "failure: with an invalid id" do
         instance = Container.create!(attributes)
 
-        get(instance_path(instance.id * 1000))
+        missing_id = instance.id * 1000
+        get(instance_path(missing_id))
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find Container with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
     end

--- a/spec/requests/api/v0.0/source_types_spec.rb
+++ b/spec/requests/api/v0.0/source_types_spec.rb
@@ -78,11 +78,12 @@ RSpec.describe("v0.0 - SourceTypes") do
       it "failure: with an invalid id" do
         instance = SourceType.create!(attributes)
 
-        get(instance_path(instance.id * 1000))
+        missing_id = instance.id * 1000
+        get(instance_path(missing_id))
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find SourceType with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
     end

--- a/spec/requests/api/v0.0/sources_spec.rb
+++ b/spec/requests/api/v0.0/sources_spec.rb
@@ -80,11 +80,12 @@ RSpec.describe("v0.0 - Sources") do
       it "failure: with an invalid id" do
         instance = Source.create!(attributes)
 
-        get(instance_path(instance.id * 1000))
+        missing_id = instance.id * 1000
+        get(instance_path(missing_id))
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find Source with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
     end
@@ -108,11 +109,12 @@ RSpec.describe("v0.0 - Sources") do
         instance = Source.create!(attributes)
         new_attributes = {"name" => "new name"}
 
-        patch(instance_path(instance.id * 1000), :params => new_attributes.to_json)
+        missing_id = instance.id * 1000
+        patch(instance_path(missing_id), :params => new_attributes.to_json)
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find Source with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
 

--- a/spec/requests/api/v0.1/authentications_spec.rb
+++ b/spec/requests/api/v0.1/authentications_spec.rb
@@ -79,11 +79,12 @@ RSpec.describe("v0.1 - Authentications") do
       it "failure: with an invalid id" do
         instance = Authentication.create!(attributes)
 
-        get(instance_path(instance.id * 1000))
+        missing_id = instance.id * 1000
+        get(instance_path(missing_id))
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find Authentication with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
     end

--- a/spec/requests/api/v0.1/service_offering_icon_spec.rb
+++ b/spec/requests/api/v0.1/service_offering_icon_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe("v0.1 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => ""
+                              :parsed_body => {"errors"=>[{"detail"=>"Couldn't find ServiceOfferingIcon with 'id'=#{missing_id}", "status"=>404}]},
                             )
       end
 
@@ -65,7 +65,7 @@ RSpec.describe("v0.1 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => ""
+                              :parsed_body => {"errors"=>[{"detail"=>"Couldn't find ServiceOfferingIcon with 'id'=0", "status"=>404}]},
                             )
       end
     end

--- a/spec/requests/api/v0.1/shared_examples_for_index.rb
+++ b/spec/requests/api/v0.1/shared_examples_for_index.rb
@@ -45,11 +45,12 @@ RSpec.shared_examples "test_index_and_subcollections" do |primary_collection, su
       it "failure: with an invalid id" do
         instance = primary_collection.to_s.singularize.camelize.constantize.create!(attributes)
 
-        get(instance_path(instance.id * 1000))
+        missing_id = instance.id * 1000
+        get(instance_path(missing_id))
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => ""
+                              :parsed_body => {"errors" => [{"detail" => "Couldn't find #{primary_collection.to_s.singularize.camelize} with 'id'=#{missing_id}", "status" => 404}]}
                             )
       end
 
@@ -58,7 +59,7 @@ RSpec.shared_examples "test_index_and_subcollections" do |primary_collection, su
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => ""
+                              :parsed_body => {"errors" => [{"detail" => "Couldn't find #{primary_collection.to_s.singularize.camelize} with 'id'=#{"non_numeric_id"}", "status" => 404}]}
                             )
       end
     end

--- a/spec/requests/api/v0.1/sources_spec.rb
+++ b/spec/requests/api/v0.1/sources_spec.rb
@@ -85,11 +85,12 @@ RSpec.describe("v0.0 - Sources") do
         instance = Source.create!(attributes)
         new_attributes = {"name" => "new name"}
 
-        patch(instance_path(instance.id * 1000), :params => new_attributes.to_json)
+        missing_id = instance.id * 1000
+        patch(instance_path(missing_id), :params => new_attributes.to_json)
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => ""
+          :parsed_body => {"errors"=>[{"detail"=>"Couldn't find Source with 'id'=#{missing_id}", "status"=>404}]}
         )
       end
 


### PR DESCRIPTION
There were a lot of extra rescue RecordNotFound which could be handled
by the base ApplicationController's rescue_from