### PR TITLE
Switch to publish_topic for Task#update messages sent to catalog-api

### DIFF
--- a/app/controllers/api/v0x1/tasks_controller.rb
+++ b/app/controllers/api/v0x1/tasks_controller.rb
@@ -6,9 +6,9 @@ module Api
       def update
         model.update(params.require(:id), params_for_update)
 
-        messaging_client.publish_message(
+        messaging_client.publish_topic(
           :service => "platform.topological-inventory.task-output-stream",
-          :message => "Task.update",
+          :event   => "Task.update",
           :payload => params_for_update.to_h.merge("task_id" => params.require(:id))
         )
 

--- a/spec/controllers/api/v0x1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v0x1/tasks_controller_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Api::V0x1::TasksController, :type => :request do
 
   before do
     allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
-    allow(client).to receive(:publish_message)
+    allow(client).to receive(:publish_topic)
   end
 
   it "patch /tasks/:id updates a Task" do
     task = Task.create!(:state => "running", :status => "ok", :context => "context1", :tenant => tenant)
-    expect(client).to receive(:publish_message).with(
+    expect(client).to receive(:publish_topic).with(
       :service => "platform.topological-inventory.task-output-stream",
-      :message => "Task.update",
+      :event   => "Task.update",
       :payload => {"state" => "completed", "status" => "ok", "context" => "context2", "task_id" => task.id.to_s}
     )
 


### PR DESCRIPTION
After talking with @mkanoor and @bzwei about the messages we were using, we came to the conclusion that the messages that are being published by the Task#update method should probably be events instead (which uses the `#publish_topic` method). So, this PR simply makes that change.

The corresponding [catalog PR is here](https://github.com/ManageIQ/catalog-api/pull/184).

@miq-bot assign @agrare 

@agrare Pretty simply change, but can you take a  👀?