### PR TITLE
Fix a state mutation race condition in substitute_references.

### DIFF
--- a/lib/open_api/docs/component_collection.rb
+++ b/lib/open_api/docs/component_collection.rb
@@ -43,8 +43,8 @@ module OpenApi
         if object.kind_of?(Array)
           object.collect { |i| substitute_regexes(i) }
         elsif object.kind_of?(Hash)
-          object.each do |k, v|
-            object[k] = k == "pattern" ? regexp_from_pattern(v) : substitute_regexes(v)
+          object.each_with_object({}) do |(k, v), o|
+            o[k] = k == "pattern" ? regexp_from_pattern(v) : substitute_regexes(v)
           end
         else
           object
@@ -52,7 +52,6 @@ module OpenApi
       end
 
       def regexp_from_pattern(pattern)
-        return pattern if pattern.kind_of?(Regexp)
         raise "Pattern #{pattern.inspect} is not a regular expression" unless pattern.starts_with?("/") && pattern.ends_with?("/")
         Regexp.new(pattern[1..-2])
       end


### PR DESCRIPTION
Because the `substitute_references` is called in parallel even the line
```
  object.each do |k, v|
    object[k] = ...
```
can get called in parallel. This results in the 2 (or more) threads
updating the structure passed in all the way by reference interfering
with each other.

For reference, the original problem's stacktrace:
```
[----] F, [2019-04-01T09:58:16.908016 #27866:1ab227c] FATAL -- : NoMethodError (undefined method `starts_with?' for /^\d+$/:Regexp):
[----] F, [2019-04-01T09:58:16.908057 #27866:1ab227c] FATAL -- :                                                                                                                                                  
[----] F, [2019-04-01T09:58:16.908102 #27866:1ab227c] FATAL -- : lib/open_api/docs/component_collection.rb:57:in `regexp_from_pattern'                                                                            
lib/open_api/docs/component_collection.rb:48:in `block in substitute_regexes'                                                                                                                                     
lib/open_api/docs/component_collection.rb:47:in `each'                                                                                                                                                            
lib/open_api/docs/component_collection.rb:47:in `substitute_regexes'                                                                                                                                              
lib/open_api/docs/component_collection.rb:19:in `load_definition'                                                                                                                                                 
lib/open_api/docs/component_collection.rb:12:in `[]'                                                                                                                                                              
lib/open_api/docs/component_collection.rb:39:in `public_send'                                                                                                                                                      lib/open_api/docs/component_collection.rb:39:in `fetch_ref_value'                                                                                                                    
lib/open_api/docs/component_collection.rb:30:in `substitute_references'                                                                                                                                           
lib/open_api/docs/component_collection.rb:31:in `block in substitute_references'                                                                                                                                   
lib/open_api/docs/component_collection.rb:31:in `each'                                                                                                                                                             
lib/open_api/docs/component_collection.rb:31:in `substitute_references'                                                                                                                                           
lib/open_api/docs/component_collection.rb:31:in `block in substitute_references'                                             
lib/open_api/docs/component_collection.rb:31:in `each'                             
lib/open_api/docs/component_collection.rb:31:in `substitute_references'                                                                                                                                           
lib/open_api/docs/component_collection.rb:20:in `load_definition'                                                                                                                                                 
lib/open_api/docs/component_collection.rb:12:in `[]'                                                                                                                                                              
app/controllers/application_controller.rb:30:in `api_doc_definition'                                                                                                                                              
app/controllers/application_controller.rb:152:in `api_doc_definition'                                                                                                                                              app/controllers/application_controller.rb:64:in `permitted_params'                                                                            
app/controllers/application_controller.rb:60:in `safe_params_for_list'                                                                                                                                            
app/controllers/application_controller.rb:124:in `filtered'                                                                                                                          
app/controllers/api/v0x1/mixins/index_mixin.rb:8:in `index'      
```