### PR TITLE
OpenAPI 3.0.0 Filter parameter

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -113,7 +113,8 @@ class OpenapiGenerator
       "description" => "Returns an array of #{klass_name} objects",
       "parameters"  => [
         { "$ref" => "##{PARAMETERS_PATH}/QueryLimit"  },
-        { "$ref" => "##{PARAMETERS_PATH}/QueryOffset" }
+        { "$ref" => "##{PARAMETERS_PATH}/QueryOffset" },
+        { "$ref" => "##{PARAMETERS_PATH}/QueryFilter" }
       ],
       "responses"   => {
         "200" => {
@@ -328,6 +329,18 @@ class OpenapiGenerator
         "minimum" => 1,
         "maximum" => 1000,
         "default" => 100
+      }
+    }
+
+    parameters["QueryFilter"] = {
+      "in"          => "query",
+      "name"        => "filter",
+      "description" => "Filter for querying collections.",
+      "required"    => false,
+      "style"       => "deepObject",
+      "explode"     => true,
+      "schema"      => {
+        "type" => "object"
       }
     }
 

--- a/public/doc/openapi-3-v0.1.0.json
+++ b/public/doc/openapi-3-v0.1.0.json
@@ -31,6 +31,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -85,6 +88,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -188,6 +194,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -323,6 +332,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -379,6 +391,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -409,6 +424,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -437,6 +455,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -493,6 +514,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -521,6 +545,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -577,6 +604,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -607,6 +637,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -635,6 +668,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -691,6 +727,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -719,6 +758,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -751,6 +793,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -781,6 +826,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -809,6 +857,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -863,6 +914,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -919,6 +973,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -947,6 +1004,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1001,6 +1061,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1138,6 +1201,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -1166,6 +1232,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1231,6 +1300,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1285,6 +1357,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1339,6 +1414,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1420,6 +1498,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1476,6 +1557,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -1504,6 +1588,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -1536,6 +1623,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -1564,6 +1654,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1663,6 +1756,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -1691,6 +1787,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1778,6 +1877,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -1808,6 +1910,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -1836,6 +1941,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -1973,6 +2081,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2001,6 +2112,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2033,6 +2147,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2061,6 +2178,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2093,6 +2213,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2121,6 +2244,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2153,6 +2279,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2181,6 +2310,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2213,6 +2345,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2241,6 +2376,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2273,6 +2411,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2301,6 +2442,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2333,6 +2477,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2361,6 +2508,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2393,6 +2543,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2423,6 +2576,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2451,6 +2607,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -2507,6 +2666,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2535,6 +2697,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2567,6 +2732,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2595,6 +2763,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2627,6 +2798,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2655,6 +2829,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2687,6 +2864,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2715,6 +2895,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -2801,6 +2984,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -2857,6 +3043,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2885,6 +3074,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           },
           {
             "$ref": "#/components/parameters/ID"
@@ -2917,6 +3109,9 @@
             "$ref": "#/components/parameters/QueryOffset"
           },
           {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -2945,6 +3140,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -2999,6 +3197,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -3053,6 +3254,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
           }
         ],
         "responses": {
@@ -3130,6 +3334,17 @@
         "schema": {
           "type": "string",
           "pattern": "/^\\d+$/"
+        }
+      },
+      "QueryFilter": {
+        "in": "query",
+        "name": "filter",
+        "description": "Filter for querying collections.",
+        "required": false,
+        "style": "deepObject",
+        "explode": true,
+        "schema": {
+          "type": "object"
         }
       },
       "QueryLimit": {


### PR DESCRIPTION
Updated the openapi.generate tasks to add the filter[] query parameter specification and updated the openapi-3-v0.1.0.json with the updates.
    
This allows the generated client to support the filter option in the list_* methods, i.e.
    
```
      api_instance = TopologicalInventoryApiClient;:DefaultApi.new
      api_instance.list_containers(:limit => 100,
                                   :filter => { :name => { :starts_with => "a" }})
```

