### PR TITLE
Use the routing class from common for major version redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,13 +2,14 @@ Rails.application.routes.draw do
   # Disable PUT for now since rails sends these :update and they aren't really the same thing.
   def put(*_args); end
 
+  routing_helper = ManageIQ::API::Common::Routing.new(self)
   prefix = "api"
   if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
     prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
   end
 
   scope :as => :api, :module => "api", :path => prefix do
-    match "/v0/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect(:path => "/#{prefix}/v0.1/%{path}", :only_path => true)
+    routing_helper.redirect_major_version("v0.1", prefix)
 
     namespace :v0x1, :path => "v0.1" do
       get "/openapi.json", :to => "root#openapi"
@@ -157,7 +158,7 @@ Rails.application.routes.draw do
   end
 
   scope :as => :internal, :module => "internal", :path => "internal" do
-    match "/v0/*path", :via => [:get], :to => redirect(:path => "/internal/v0.0/%{path}", :only_path => true)
+    routing_helper.redirect_major_version("v0.0", "internal", :via => [:get])
 
     namespace :v0x0, :path => "v0.0" do
       resources :authentications, :only => [:show]

--- a/spec/requests/api/v0_redirect_spec.rb
+++ b/spec/requests/api/v0_redirect_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe("v0 redirects") do
+  let(:expected_version) { "v0.1" }
+
+  describe("/api/v0") do
+    it "redirects to the latest minor version" do
+      get("/api/v0/vms")
+      expect(response.status).to eq(302)
+      expect(response.headers["Location"]).to eq("/api/#{expected_version}/vms")
+    end
+
+    it "preserves the openapi.json file extension when using a redirect" do
+      get("/api/v0/openapi.json")
+      expect(response.status).to eq(302)
+      expect(response.headers["Location"]).to eq("/api/#{expected_version}/openapi.json")
+    end
+
+    it "preserves the openapi.json file extension when not using a redirect" do
+      get("/api/#{expected_version}/openapi.json")
+      expect(response.status).to eq(200)
+      expect(response.headers["Location"]).to be_nil
+    end
+
+    it "direct request doesn't break vms" do
+      get("/api/#{expected_version}/vms")
+      expect(response.status).to eq(200)
+      expect(response.headers["Location"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-api-common/pull/50