### PR TITLE
[WIP] Use the common routing helper for major version redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,13 +2,15 @@ Rails.application.routes.draw do
   # Disable PUT for now since rails sends these :update and they aren't really the same thing.
   def put(*_args); end
 
+  routing_helper = ManageIQ::API::Common::Routing.new(self)
+
   prefix = "api"
   if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
     prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
   end
 
   scope :as => :api, :module => "api", :path => prefix do
-    match "/v0/*path", :via => [:delete, :get, :options, :patch, :post], :to => redirect(:path => "/#{prefix}/v0.1/%{path}", :only_path => true)
+    routing_helper.redirect_major_version("v0.1", prefix)
 
     namespace :v0x1, :path => "v0.1" do
       get "/openapi.json", :to => "root#openapi"
@@ -157,7 +159,7 @@ Rails.application.routes.draw do
   end
 
   scope :as => :internal, :module => "internal", :path => "internal" do
-    match "/v0/*path", :via => [:get], :to => redirect(:path => "/internal/v0.0/%{path}", :only_path => true)
+    routing_helper.redirect_major_version("v0.0", "internal", :via => [:get])
 
     namespace :v0x0, :path => "v0.0" do
       resources :authentications, :only => [:show]


### PR DESCRIPTION
Requires https://github.com/ManageIQ/manageiq-api-common/pull/50

This also fixes the issue where a request to /openapi.json would
be redirected to /openapi