### PR TITLE
Updated openapi:generate to know about the individual IconData image type

### DIFF
--- a/public/doc/openapi-3-v0.1.0.json
+++ b/public/doc/openapi-3-v0.1.0.json
@@ -1462,9 +1462,9 @@
     },
     "/service_offering_icons/{id}/icon_data": {
       "get": {
-        "summary": "Show an existing ServiceOfferingIcon",
-        "operationId": "showServiceOfferingIcon",
-        "description": "Returns a ServiceOfferingIcon object",
+        "summary": "Show an existing ServiceOfferingIcon IconData",
+        "operationId": "showServiceOfferingIconIconData",
+        "description": "Returns a ServiceOfferingIcon IconData",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -1472,11 +1472,12 @@
         ],
         "responses": {
           "200": {
-            "description": "ServiceOfferingIcon info",
+            "description": "ServiceOfferingIcon IconData",
             "content": {
-              "application/json": {
+              "image/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/ServiceOfferingIcon"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
@@ -5057,32 +5058,6 @@
             "items": {
               "$ref": "#/components/schemas/Task"
             }
-          }
-        }
-      },
-      "Tenant": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "readOnly": true,
-            "format": "uuid"
-          },
-          "name": {
-            "type": "string",
-            "example": "Sample Tenant",
-            "title": "Name",
-            "readOnly": true
-          },
-          "description": {
-            "type": "string",
-            "description": "Description of the Tenant",
-            "readOnly": true
-          },
-          "external_tenant": {
-            "type": "string",
-            "description": "External tenant identifier",
-            "readOnly": true
           }
         }
       },


### PR DESCRIPTION

Updated openapi:generate to know about the individual IconData image type 
- updated lib/tasks/openapi_generate.rake
- updated public/doc/openapi-3-v0.1.0.json

_Note_: the generated openapi json removed the Tenants definition from 0.1.0 as that is only exposed with the internal v0.0 api.