### PR TITLE
Return the proper error message for invalid URLs

### DIFF
--- a/app/controllers/api.rb
+++ b/app/controllers/api.rb
@@ -1,2 +1,8 @@
 module Api
+  class RootController < ApplicationController
+    def invalid_url_error
+      error_document = ManageIQ::API::Common::ErrorDocument.new.add(404, "Invalid URL /#{params[:path]} specified.")
+      render :json => error_document.to_h, :status => :not_found
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,4 +170,6 @@ Rails.application.routes.draw do
       resources :tenants, :only => [:index, :show]
     end
   end
+
+  match "*path", :to => "api/root#invalid_url_error", :via => ActionDispatch::Routing::HTTP_METHODS
 end

--- a/spec/requests/general_spec.rb
+++ b/spec/requests/general_spec.rb
@@ -1,0 +1,22 @@
+RSpec.shared_examples "invalid_url_requests" do |request_type, invalid_url|
+  include ::Spec::Support::TenantIdentity
+
+  let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+
+  context "with invalid #{request_type} URLs" do
+    it "fail with an error object" do
+      get(invalid_url, :headers => headers)
+
+      expect(response).to have_attributes(
+        :status      => 404,
+        :parsed_body => {"errors" => [{"detail" => "Invalid URL #{invalid_url} specified.", "status" => 404}]}
+      )
+    end
+  end
+end
+
+RSpec.describe("Requests") do
+  include_examples("invalid_url_requests", "api", "/api/v9999/bogus_collection")
+  include_examples("invalid_url_requests", "internal", "/internal/v9999/unpublished_collection")
+  include_examples("invalid_url_requests", "", "/bogus_url")
+end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -4,6 +4,7 @@ describe "Swagger stuff" do
       r = ActionDispatch::Routing::RouteWrapper.new(route)
       next if r.internal? # Don't display rails routes
       next if r.engine? # Don't care right now...
+      next if r.action == "invalid_url_error"
 
       array << {:verb => r.verb, :path => r.path.split("(").first.sub(/:[_a-z]*id/, ":id")}
     end


### PR DESCRIPTION
Adding a catch-all in the routes so we can return the proper error message with the 404.