### PR TITLE
Entitlement enforcement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,7 @@ class ApplicationController < ActionController::API
 
   def request_is_entitled?(entitlement)
     required_entitlements = %i[hybrid_cloud? insights?]
-    required_entitlements.map { |e| entitlement.send(e) }.any?
+    required_entitlements.any? { |e| entitlement.send(e) }
   end
 
   def body_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,8 @@ class ApplicationController < ActionController::API
       rescue KeyError, ManageIQ::API::Common::IdentityError
         render :json => { :message => 'Unauthorized' }, :status => :unauthorized
       rescue ManageIQ::API::Common::EntitlementError
-        render :json => { :message => 'Forbidden' }, :status => :forbidden
+        error_document = ManageIQ::API::Common::ErrorDocument.new.add(403, 'Forbidden')
+        render :json => error_document.to_h, :status => error_document.status
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -68,4 +68,56 @@ RSpec.describe ApplicationController, :type => :request do
       expect(response.status).to eq(200)
     end
   end
+
+  context "with entitlement" do
+    let(:entitlements) do
+      {
+        "hybrid_cloud"     => {
+            "is_entitled" => true
+        },
+        "insights"         => {
+            "is_entitled" => true
+        }
+      }
+    end
+
+    it "permits request with all the necessary entitlements" do
+      headers = { "CONTENT_TYPE"  => "application/json", "x-rh-identity" => identity_with_entitlements }
+
+      get("/api/v1.0/sources", :headers => headers)
+
+      expect(response.status).to eq(200)
+    end
+
+    it "permits request with one of the necessary entitlements" do
+      entitlements["insights"]["is_entitled"]     = false
+
+      headers = {
+          "CONTENT_TYPE"  => "application/json",
+          "x-rh-identity" => Base64.encode64(
+              {'identity' => { 'account_number' => external_tenant}, :entitlements => entitlements}.to_json
+          )
+      }
+
+      get("/api/v1.0/sources", :headers => headers)
+
+      expect(response.status).to eq(200)
+    end
+
+    it "forbids request with none of the necessary entitlements" do
+      entitlements["insights"]["is_entitled"]     = false
+      entitlements["hybrid_cloud"]["is_entitled"] = false
+
+      headers = {
+          "CONTENT_TYPE"  => "application/json",
+          "x-rh-identity" => Base64.encode64(
+              {'identity' => { 'account_number' => external_tenant}, :entitlements => entitlements}.to_json
+          )
+      }
+
+      get("/api/v1.0/sources", :headers => headers)
+
+      expect(response.status).to eq(403)
+    end
+  end
 end

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -9,6 +9,23 @@ module Spec
         let!(:unknown_tenant)   { rand(1000).to_s }
         let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
         let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => unknown_tenant}}.to_json) }
+
+        let!(:entitlements) do
+          {
+              "hybrid_cloud"     => {
+                  "is_entitled" => true
+              },
+              "insights"         => {
+                  "is_entitled" => true
+              }
+          }
+        end
+
+        let!(:identity_with_entitlements) do
+          Base64.encode64(
+              {'identity' => { 'account_number' => external_tenant}, :entitlements => entitlements}.to_json
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
This change will enforce entitlements if the "entitlements" key is present in the x-rh-identity header.

If the "entitlements" key is present, the user must be entitled for either "insights" or "hybrid_cloud". I neither is entitled a 403 response is returned