### PR TITLE
Sources API should only be exposed read-only.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
         post "order", :to => "service_plans#order"
         resources :service_instances, :only => [:index]
       end
-      resources :sources,                 :only => [:create, :destroy, :index, :show, :update] do
+      resources :sources,                 :only => [:index, :show] do
         resources :availabilities,          :only => [:index]
         resources :containers,              :only => [:index]
         resources :container_groups,        :only => [:index]

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1333,37 +1333,6 @@
             }
           }
         }
-      },
-      "post": {
-        "summary": "Create a new Source",
-        "operationId": "createSource",
-        "description": "Creates a Source object",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Source"
-              }
-            }
-          },
-          "description": "Source attributes to create",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Source creation successful",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "items": {
-                    "$ref": "#/components/schemas/Source"
-                  }
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/sources/{id}": {
@@ -1386,56 +1355,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Not found"
-          }
-        }
-      },
-      "patch": {
-        "summary": "Update an existing Source",
-        "operationId": "updateSource",
-        "description": "Updates a Source object",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/ID"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Source"
-              }
-            }
-          },
-          "description": "Source attributes to update",
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "Updated, no content"
-          },
-          "400": {
-            "description": "Bad request"
-          },
-          "404": {
-            "description": "Not found"
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete an existing Source",
-        "operationId": "deleteSource",
-        "description": "Deletes a Source object",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/ID"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Source deleted"
           },
           "404": {
             "description": "Not found"

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -1,6 +1,6 @@
 require_relative "shared_examples_for_index"
 
-RSpec.describe("v0.0 - Sources") do
+RSpec.describe("v1.0 - Sources") do
   include ::Spec::Support::TenantIdentity
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }


### PR DESCRIPTION

Sources API should only be exposed read-only.
Routes and OpenAPI json spec was still allowing creates, updates and deletes even though the code did not.