### PR TITLE
Remove Api::Docs.content.to_json

### DIFF
--- a/app/controllers/api/v0x1.rb
+++ b/app/controllers/api/v0x1.rb
@@ -2,7 +2,7 @@ module Api
   module V0x1
     class RootController < ApplicationController
       def openapi
-        render :json => Api::Docs["0.1"].content.to_json
+        render :json => Api::Docs["0.1"].to_json
       end
     end
 

--- a/app/controllers/api/v1x0.rb
+++ b/app/controllers/api/v1x0.rb
@@ -2,7 +2,7 @@ module Api
   module V1x0
     class RootController < ApplicationController
       def openapi
-        render :json => Api::Docs["1.0"].content.to_json
+        render :json => Api::Docs["1.0"].to_json
       end
     end
 


### PR DESCRIPTION
The .content shouldn't be needed now that OpenApi::Docs to_json method
returns .content