### PR TITLE
Fix for POST create openapi JSON signatures.

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -297,10 +297,7 @@ class OpenapiGenerator
           "description" => "#{klass_name} creation successful",
           "content"     => {
             "application/json" => {
-              "schema" => {
-                "type"  => "object",
-                "items" => { "$ref" => build_schema(klass_name) }
-              }
+              "schema" => { "$ref" => build_schema(klass_name) }
             }
           }
         }


### PR DESCRIPTION
Fix for POST create openapi JSON signatures.  

Response signatures like:

         "content": {
           "application/json": {
             "schema": {
               "type": "object",
               "items": {
                 "$ref": "#/components/schemas/<<Collection>>"
               }
             }
           }
         }

  Should just be for simple json objects and not arrays:

         "content": {
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/<<Collection>>"
             }
           }
         }

Updating the openapi:generate tasks only as none of the entries in the topological inventory openapi spec included such endpoints, those were moved to the sources api.