### PR TITLE
Move internal api v1x0

### DIFF
--- a/app/controllers/internal/v1/tenants_controller.rb
+++ b/app/controllers/internal/v1/tenants_controller.rb
@@ -1,0 +1,8 @@
+module Internal
+  module V1
+    class TenantsController < ::ApplicationController
+      include Api::V0::Mixins::IndexMixin
+      include Api::V0::Mixins::ShowMixin
+    end
+  end
+end

--- a/app/controllers/internal/v1x0.rb
+++ b/app/controllers/internal/v1x0.rb
@@ -1,0 +1,5 @@
+module Internal
+  module V1x0
+    class TenantsController < Internal::V1::TenantsController; end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,8 +171,13 @@ Rails.application.routes.draw do
 
   scope :as => :internal, :module => "internal", :path => "internal" do
     routing_helper.redirect_major_version("v0.0", "internal", :via => [:get])
+    routing_helper.redirect_major_version("v1.0", "internal", :via => [:get])
 
     namespace :v0x0, :path => "v0.0" do
+      resources :tenants, :only => [:index, :show]
+    end
+
+    namespace :v1x0, :path => "v1.0" do
       resources :tenants, :only => [:index, :show]
     end
   end

--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -416,6 +416,16 @@ class OpenapiGenerator
       }
     }
 
+    schemas["Tenant"] = {
+      "type"       => "object",
+      "properties" => {
+        "id"              => {"type" => "string", "readOnly" => true, "format" => "uuid"},
+        "name"            => {"type" => "string", "readOnly" => true, "example" => "Sample Tenant"},
+        "description"     => {"type" => "string", "readOnly" => true, "example" => "Description of the Tenant"},
+        "external_tenant" => {"type" => "string", "readOnly" => true, "example" => "External tenant identifier"}
+      }
+    }
+
     schemas["Tagging"] = {
       "type"       => "object",
       "properties" => {

--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -419,7 +419,7 @@ class OpenapiGenerator
     schemas["Tenant"] = {
       "type"       => "object",
       "properties" => {
-        "id"              => {"type" => "string", "readOnly" => true, "format" => "uuid"},
+        "id"              => {"$ref" => "##{SCHEMAS_PATH}/ID"},
         "name"            => {"type" => "string", "readOnly" => true, "example" => "Sample Tenant"},
         "description"     => {"type" => "string", "readOnly" => true, "example" => "Description of the Tenant"},
         "external_tenant" => {"type" => "string", "readOnly" => true, "example" => "External tenant identifier"}

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -4074,9 +4074,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "readOnly": true,
-            "format": "uuid"
+            "$ref": "#/components/schemas/ID"
           },
           "name": {
             "type": "string",

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -4070,6 +4070,31 @@
           }
         }
       },
+      "Tenant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true,
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "readOnly": true,
+            "example": "Sample Tenant"
+          },
+          "description": {
+            "type": "string",
+            "readOnly": true,
+            "example": "Description of the Tenant"
+          },
+          "external_tenant": {
+            "type": "string",
+            "readOnly": true,
+            "example": "External tenant identifier"
+          }
+        }
+      },
       "Vm": {
         "type": "object",
         "properties": {

--- a/spec/controllers/internal/v1x0/tenants_controller_spec.rb
+++ b/spec/controllers/internal/v1x0/tenants_controller_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Internal::V1x0::TenantsController, :type => :request do
+  include ::Spec::Support::TenantIdentity
+
+  let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+
+  it "GET an instance" do
+    get(internal_v1x0_tenant_url(tenant.id), :headers => headers)
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body).to include(
+      "id"              => tenant.id.to_s,
+      "name"            => "default",
+      "external_tenant" => external_tenant
+    )
+  end
+end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -50,6 +50,9 @@ describe "Swagger stuff" do
           {:path => "/internal/v0/*path",                 :verb => "GET"},
           {:path => "/internal/v0.0/tenants",             :verb => "GET"},
           {:path => "/internal/v0.0/tenants/:id",         :verb => "GET"},
+          {:path => "/internal/v1/*path",                 :verb => "GET"},
+          {:path => "/internal/v1.0/tenants",             :verb => "GET"},
+          {:path => "/internal/v1.0/tenants/:id",         :verb => "GET"},
         ]
         expect(rails_routes).to match_array(swagger_routes + non_swagger_routes + redirect_routes + internal_api_routes)
       end


### PR DESCRIPTION
We'll need to work with AIOPS to make sure they update any of their code which uses the internal API to get tenants