### PR TITLE
[DEPENDS ON https://github.com/ManageIQ/manageiq-api-common/pull/82] Fix constant problems

### DIFF
--- a/app/controllers/api/v0x1.rb
+++ b/app/controllers/api/v0x1.rb
@@ -2,7 +2,7 @@ module Api
   module V0x1
     class RootController < ApplicationController
       def openapi
-        render :json => Api::Docs["0.1"].to_json
+        render :json => ::ManageIQ::API::Common::OpenApi::Docs.instance["0.1"].to_json
       end
     end
 

--- a/app/controllers/api/v1x0.rb
+++ b/app/controllers/api/v1x0.rb
@@ -2,7 +2,7 @@ module Api
   module V1x0
     class RootController < ApplicationController
       def openapi
-        render :json => Api::Docs["1.0"].to_json
+        render :json => ::ManageIQ::API::Common::OpenApi::Docs.instance["1.0"].to_json
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::API
   end
 
   private_class_method def self.api_doc_definition
-    @api_doc_definition ||= Api::Docs[api_version[1..-1].sub(/x/, ".")].definitions[model.name]
+    @api_doc_definition ||= ::ManageIQ::API::Common::OpenApi::Docs.instance[api_version[1..-1].sub(/x/, ".")].definitions[model.name]
   end
 
   private_class_method def self.api_version

--- a/lib/api/docs.rb
+++ b/lib/api/docs.rb
@@ -1,3 +1,0 @@
-module Api
-  Docs = ::ManageIQ::API::Common::OpenApi::Docs.new(Dir.glob(Rails.root.join("public", "doc", "openapi*.json")))
-end

--- a/spec/support/json_schema_matcher.rb
+++ b/spec/support/json_schema_matcher.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :match_json_schema do |version, schema|
   match do |parsed_body|
-    s = Api::Docs[version].definitions[schema]
+    s = ::ManageIQ::API::Common::OpenApi::Docs.instance[version].definitions[schema]
     JSON::Validator.validate!(s, parsed_body)
   end
 end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -14,7 +14,7 @@ describe "Swagger stuff" do
     published_versions = rails_routes.collect do |rails_route|
       (version_match = rails_route[:path].match(/\/api\/topological-inventory\/v([\d]+\.[\d])\/openapi.json$/)) && version_match[1]
     end.compact
-    Api::Docs.routes.select do |spec_route|
+    ::ManageIQ::API::Common::OpenApi::Docs.instance.routes.select do |spec_route|
       published_versions.include?(spec_route[:path].match(/\/api\/topological-inventory\/v([\d]+\.[\d])\//)[1])
     end
   end
@@ -90,7 +90,7 @@ describe "Swagger stuff" do
   end
 
   describe "Model serialization" do
-    let(:doc) { Api::Docs[version] }
+    let(:doc) { ::ManageIQ::API::Common::OpenApi::Docs.instance[version] }
     let(:container) { Container.create!(doc.example_attributes("Container").symbolize_keys.merge(:tenant => tenant, :container_group => container_group, :container_image => container_image)) }
     let(:container_group) { ContainerGroup.create!(doc.example_attributes("ContainerGroup").symbolize_keys.merge(:tenant => tenant, :source => source, :container_node => container_node, :container_project => container_project, :source_created_at => Time.now, :source_ref => SecureRandom.uuid)) }
     let(:container_image) { ContainerImage.create!(doc.example_attributes("ContainerImage").symbolize_keys.merge(:tenant => tenant, :source => source, :source_created_at => Time.now, :source_ref => SecureRandom.uuid)) }
@@ -117,7 +117,7 @@ describe "Swagger stuff" do
 
     context "v1.0" do
       let(:version) { "1.0" }
-      Api::Docs["1.0"].definitions.each do |definition_name, schema|
+      ::ManageIQ::API::Common::OpenApi::Docs.instance["1.0"].definitions.each do |definition_name, schema|
         next if definition_name.in?(["CollectionLinks", "CollectionMetadata", "OrderParameters", "Tagging"])
         definition_name = definition_name.sub(/Collection\z/, "").singularize
 
@@ -130,7 +130,7 @@ describe "Swagger stuff" do
 
     context "v0.1" do
       let(:version) { "0.1" }
-      Api::Docs["0.1"].definitions.each do |definition_name, schema|
+      ::ManageIQ::API::Common::OpenApi::Docs.instance["0.1"].definitions.each do |definition_name, schema|
         next if definition_name.in?(["CollectionLinks", "CollectionMetadata", "OrderParameters", "Tagging"])
         definition_name = definition_name.sub(/Collection\z/, "").singularize
 


### PR DESCRIPTION
Occasionally we get an error about missing constant ManageIQ::Api::Docs
which should be actually be finding ::Api::Docs in lib/api/docs.rb in the
apps, but for some reason that isn't loaded yet.  Instead, move all of this
logic to manageiq-api-common and create
::ManageIQ::API::Common::OpenApi::Docs.instance