### PR TITLE
Fix a reference to Api::V0 which was removed

### DIFF
--- a/app/controllers/internal/v1/tenants_controller.rb
+++ b/app/controllers/internal/v1/tenants_controller.rb
@@ -1,8 +1,8 @@
 module Internal
   module V1
     class TenantsController < ::ApplicationController
-      include Api::V0::Mixins::IndexMixin
-      include Api::V0::Mixins::ShowMixin
+      include Api::V1::Mixins::IndexMixin
+      include Api::V1::Mixins::ShowMixin
     end
   end
 end


### PR DESCRIPTION
The V0 API was removed inhttps://github.com/ManageIQ/topological_inventory-api/pull/198 but this reference was missed.