### PR TITLE
Choosing service plan order target

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'rails',              '>= 5.2.2.1', '~> 5.2.2'
 
 gem 'inventory_refresh', :git => 'https://github.com/ManageIQ/inventory_refresh', :branch => 'master'
 gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-common', :branch => 'master'
+gem 'sources-api-client',         :git => 'https://github.com/ManageIQ/sources-api-client-ruby', :branch => 'master'
 gem 'topological_inventory-core', :git => 'https://github.com/ManageIQ/topological_inventory-core', :branch => 'master'
 
 group :development, :test do

--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -1,3 +1,5 @@
+require "sources-api-client"
+
 module Api
   module V1
     class ServicePlansController < ApplicationController
@@ -6,20 +8,58 @@ module Api
 
       def order
         service_plan = model.find(params_for_order[:service_plan_id].to_i)
-        task = Task.create!(:tenant => service_plan.tenant, :state => "pending", :status => "ok")
 
-        messaging_client.publish_message(
-          :service => "platform.topological-inventory.operations-openshift",
-          :message => "ServicePlan.order",
-          :payload => payload_for_order(task, service_plan)
-        )
+        retrieve_source_type(service_plan) do |source_type|
+          task = Task.create!(:tenant => service_plan.tenant, :state => "pending", :status => "ok")
 
-        render :json => {:task_id => task.id}
+          messaging_client.publish_message(
+            :service => "platform.topological-inventory.operations-#{source_type.name}",
+            :message => "ServicePlan.order",
+            :payload => payload_for_order(task, service_plan)
+          )
+
+          render :json => {:task_id => task.id}
+        end
+
       rescue ActiveRecord::RecordNotFound
         head :bad_request
+      rescue StandardError => err
+        error_document = ManageIQ::API::Common::ErrorDocument.new.add(err.message)
+        render :json => error_document.to_h, :status => error_document.status
       end
 
       private
+
+      def sources_api_client
+        @sources_api_client ||=
+          begin
+            identity = { 'x-rh-identity' => request.headers.fetch('x-rh-identity') }
+            api_client = SourcesApiClient::ApiClient.new
+            api_client.default_headers.merge!(identity)
+            SourcesApiClient::DefaultApi.new(api_client)
+          end
+      end
+
+      def retrieve_source_type(service_plan)
+        source = sources_api_client.show_source(service_plan.source_id.to_s)
+        if source.present?
+          source_type = sources_api_client.show_source_type(source.source_type_id.to_s)
+          if source_type.present?
+            #
+            # Process Source Type
+            #
+            yield source_type
+          else
+            raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source Type (ID #{source.source_type_id.to_s})")
+          end
+        else
+          raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source (ID #{service_plan.source_id.to_s})")
+        end
+
+      # Add Sources API message prefix
+      rescue SourcesApiClient::ApiError => err
+        raise SourcesApiClient::ApiError.new(:message => "Sources API: #{err.message} (code #{err.code})")
+      end
 
       def params_for_order
         @params_for_order ||= params.permit(

--- a/config/initializers/sources_api.rb
+++ b/config/initializers/sources_api.rb
@@ -1,0 +1,8 @@
+scheme = ENV["SOURCES_SCHEME"] || 'http'
+host = ENV["SOURCES_HOST"] || 'localhost'
+port = ENV["SOURCES_PORT"] || 3000
+
+SourcesApiClient.configure do |config|
+  config.scheme = scheme
+  config.host   = "#{host}:#{port}"
+end

--- a/spec/controllers/api/v1x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v1x0/service_plans_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Api::V1x0::ServicePlansController, :type => :request do
 
         source_type = double
         allow(source_type).to receive(:name).and_return("openshift")
-        allow_any_instance_of(described_class).to receive(:retrieve_source_type).and_yield(source_type)
+        allow_any_instance_of(described_class).to receive(:retrieve_source_type).and_return(source_type)
       end
 
       it "publishes a message to the messaging client" do


### PR DESCRIPTION
Based on Sources API source type.

Kafka queue's name suffix is chosen by `SourceType.name` (ServicePlan -> Source -> SourceType)

---

**related to** https://github.com/ManageIQ/topological_inventory-ansible_tower/pull/12