### PR TITLE
Select the closest manifest to the version provided

### DIFF
--- a/app/controllers/api/cfme/manifest_controller.rb
+++ b/app/controllers/api/cfme/manifest_controller.rb
@@ -6,7 +6,7 @@ module Api
         raise ActionController::RoutingError.new('Not Found') unless version =~ /\A[\d\.]+\Z/
 
         file = TopologicalInventory::Api::CfmeManifest.find(version)
-        raise ActionController::RoutingError.new('Not Found') unless file.exist?
+        raise ActionController::RoutingError.new('Not Found') unless file&.exist?
 
         render :json => file.read
       end

--- a/app/controllers/api/cfme/manifest_controller.rb
+++ b/app/controllers/api/cfme/manifest_controller.rb
@@ -6,7 +6,7 @@ module Api
         raise ActionController::RoutingError.new('Not Found') unless version =~ /\A[\d\.]+\Z/
 
         file = TopologicalInventory::Api::CfmeManifest.find(version)
-        raise ActionController::RoutingError.new('Not Found') unless file&.exist?
+        raise ActionController::RoutingError.new('Not Found') if file.nil?
 
         render :json => file.read
       end

--- a/app/controllers/api/cfme/manifest_controller.rb
+++ b/app/controllers/api/cfme/manifest_controller.rb
@@ -4,9 +4,8 @@ module Api
       def show
         version = params.permit(:id)[:id]
         raise ActionController::RoutingError.new('Not Found') unless version =~ /\A[\d\.]+\Z/
-        version.gsub!(".", "_")
 
-        file = Rails.root.join("config", "cfme", "manifest_#{version}.json")
+        file = TopologicalInventory::Api::CfmeManifest.find(version)
         raise ActionController::RoutingError.new('Not Found') unless file.exist?
 
         render :json => file.read

--- a/lib/topological_inventory/api/cfme_manifest.rb
+++ b/lib/topological_inventory/api/cfme_manifest.rb
@@ -4,7 +4,11 @@ module TopologicalInventory
       def self.find(version)
         version.gsub!(".", "_")
 
-        manifest = nil
+        # Find the manifest file that best matches the version supplied.
+        # Look for a full match first then iteratively check for broader
+        # and broader versions.
+        #
+        # E.g. 5.11.0.0 will check for 5.11.0.0, then 5.11.0, 5.11, then 5
         until version.blank? || (manifest = manifest_by_version[version]).present?
           version = version.split("_")[0...-1].join("_")
         end
@@ -13,9 +17,11 @@ module TopologicalInventory
       end
 
       private_class_method def self.manifest_by_version
-        @manifest_by_version ||= Pathname.glob(Rails.root.join("config", "cfme", "manifest_*.json")).index_by do |file|
-          file.basename.to_s.match(/manifest_(.*)\.json/)[1]
-        end
+        # List all manifests and cache the result to prevent a readdir on every API call
+        @manifest_by_version ||=
+          Pathname.glob(Rails.root.join("config", "cfme", "manifest_*.json")).index_by do |file|
+            file.basename.to_s.match(/manifest_(.*)\.json/)[1]
+          end
       end
     end
   end

--- a/lib/topological_inventory/api/cfme_manifest.rb
+++ b/lib/topological_inventory/api/cfme_manifest.rb
@@ -1,0 +1,22 @@
+module TopologicalInventory
+  module Api
+    class CfmeManifest
+      def self.find(version)
+        version.gsub!(".", "_")
+
+        manifest = nil
+        until version.blank? || (manifest = manifest_by_version[version]).present?
+          version = version.split("_")[0...-1].join("_")
+        end
+
+        manifest
+      end
+
+      private_class_method def self.manifest_by_version
+        @manifest_by_version ||= Pathname.glob(Rails.root.join("config", "cfme", "manifest_*.json")).index_by do |file|
+          file.basename.to_s.match(/manifest_(.*)\.json/)[1]
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/cfme/manifest_spec.rb
+++ b/spec/requests/api/cfme/manifest_spec.rb
@@ -1,15 +1,18 @@
 RSpec.describe("CFME manifest") do
   include ::Spec::Support::TenantIdentity
 
-  let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:headers)  { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:manifest) { JSON.parse(Rails.root.join("config", "cfme", "manifest_5_11.json").read) }
 
   describe("/cfme/manifest") do
     it "gets a specific version" do
       get("/api/cfme/manifest/5.11", :headers => headers)
-      expect(response).to have_attributes(
-        :status      => 200,
-        :parsed_body => JSON.parse(Rails.root.join("config", "cfme", "manifest_5_11.json").read)
-      )
+      expect(response).to have_attributes(:status => 200, :parsed_body => manifest)
+    end
+
+    it "finds the closest manifest version" do
+      get("/api/cfme/manifest/5.11.1.0", :headers => headers)
+      expect(response).to have_attributes(:status => 200, :parsed_body => manifest)
     end
 
     it "disallows invalid versions" do


### PR DESCRIPTION
The CFME appliance will query for the manifest using the exact version
that it has (e.g. 5.11.0.0), we want to return the closest manifest to
that without having a manifest for every single version.

E.g.:
With the following manifests:
`[manifest_5_11.json, manifest_5_11_0.json, manifest_5_11_0_2]`

```
GET /cfme/manifest/5.11.0.0 => manifest_5_11_0.json
GET /cfme/manifest/5.11.0.2 => manifest_5_11_0_2.json
GET /cfme/manifest/5.11.1.0 => manifest_5_11.json
GET /cfme/manifest/5.11.2.0 => manifest_5_11.json
GET /cfme/manifest/5.10.4.0 => nil
```