### PR TITLE
Add info to cross ref vms to hosts, hosts to clusters

### DIFF
--- a/config/cfme/manifest_5_11.json
+++ b/config/cfme/manifest_5_11.json
@@ -33,7 +33,9 @@
         "disks_aligned": null,
         "ems_ref": null,
         "has_rdm_disk": null,
-        "host_id": null,
+        "host": {
+          "ems_ref": null
+        },
         "linked_clone": null,
         "orphaned": null,
         "power_state": null,
@@ -97,7 +99,9 @@
         "disks_aligned": null,
         "ems_ref": null,
         "has_rdm_disk": null,
-        "host_id": null,
+        "host": {
+          "ems_ref": null
+        },
         "linked_clone": null,
         "orphaned": null,
         "power_state": null,
@@ -169,10 +173,12 @@
         "archived": null,
         "cpu_cores_per_socket": null,
         "cpu_total_cores": null,
-        "ems_cluster_id": null,
+        "ems_cluster": {
+          "ems_ref": null
+        },
         "hardware": {
           "memory_mb": null
-	}
+        }
       },
       "storages": {
         "id": null,
@@ -185,7 +191,9 @@
         "storage_domain_type": null,
         "host_storages": {
           "ems_ref": null,
-          "host_id": null
+          "host": {
+            "ems_ref": null
+          }
         }
       }
     },
@@ -209,7 +217,9 @@
         "disks_aligned": null,
         "ems_ref": null,
         "has_rdm_disk": null,
-        "host_id": null,
+        "host": {
+          "ems_ref": null
+        },
         "linked_clone": null,
         "orphaned": null,
         "power_state": null,
@@ -298,10 +308,12 @@
         "archived": null,
         "cpu_cores_per_socket": null,
         "cpu_total_cores": null,
-        "ems_cluster_id": null,
+        "ems_cluster": {
+          "ems_ref": null
+        },
         "hardware": {
           "memory_mb": null
-	}
+        }
       },
       "storages": {
         "id": null,
@@ -314,7 +326,9 @@
         "storage_domain_type": null,
         "host_storages": {
           "ems_ref": null,
-          "host_id": null
+          "host": {
+            "ems_ref": null
+          }
         }
       }
     }


### PR DESCRIPTION
We use the source_ref to do lazy_finds to we need the host: {"ems_ref":
null} not the host_id.