### PR TITLE
Add a manifest version to the manifest

### DIFF
--- a/config/cfme/manifest_5_11.json
+++ b/config/cfme/manifest_5_11.json
@@ -1,6 +1,7 @@
 {
   "cfme_version": "5.11",
   "manifest": {
+    "version": "1.0.0",
     "core": {
       "MiqDatabase": {
         "id": null,


### PR DESCRIPTION
Add a version which tracks the content of the manifest for a given cfme
version.  This will indicate to any parsers if there are breaking
changes in the manifest for example:

1. If a new collection or attribute was *added* we would bump the
last component of the version number by one (e.g. 1.0.1)
2. If a collection or attribute was *removed* we would bump the second
component by one (e.g. 1.1.0)
3. If major structural changes to the manifest were made that indicate
that existing parsers would be completely incapable of processing the
payload we would bump the first component by one (e.g. 2.0.0)