### PR TITLE
Fix ServerPlan.order kafka message

### DIFF
--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -12,9 +12,9 @@ module Api
         source_type = retrieve_source_type(service_plan)
         task = Task.create!(:tenant => service_plan.tenant, :state => "pending", :status => "ok")
 
-        messaging_client.publish_message(
+        messaging_client.publish_topic(
           :service => "platform.topological-inventory.operations-#{source_type.name}",
-          :message => "ServicePlan.order",
+          :event   => "ServicePlan.order",
           :payload => payload_for_order(task, service_plan)
         )
 

--- a/spec/controllers/api/v1x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v1x0/service_plans_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Api::V1x0::ServicePlansController, :type => :request do
 
       before do
         allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
-        allow(client).to receive(:publish_message)
+        allow(client).to receive(:publish_topic)
 
         source_type = double
         allow(source_type).to receive(:name).and_return("openshift")
@@ -55,9 +55,9 @@ RSpec.describe Api::V1x0::ServicePlansController, :type => :request do
       end
 
       it "publishes a message to the messaging client" do
-        expect(client).to receive(:publish_message).with(
+        expect(client).to receive(:publish_topic).with(
           :service => "platform.topological-inventory.operations-openshift",
-          :message => "ServicePlan.order",
+          :event   => "ServicePlan.order",
           :payload => {:request_context => headers, :params => {:task_id => kind_of(String), :service_plan_id => service_plan.id.to_s, :order_params => payload}}
         )
 
@@ -85,7 +85,7 @@ RSpec.describe Api::V1x0::ServicePlansController, :type => :request do
 
       before do
         allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
-        allow(client).to receive(:publish_message)
+        allow(client).to receive(:publish_topic)
 
         allow_any_instance_of(described_class).to receive(:retrieve_source_type).and_raise(SourcesApiClient::ApiError.new(error_message))
       end


### PR DESCRIPTION
After https://github.com/ManageIQ/topological_inventory-openshift/pull/92 changed the operations worker to use subscribe_topic not subscribe_messages ordering was broken because the received_message.message was nil while led to: `undefined method `split' for nil:NilClass`

The fix is to use publish_topic instead of publish_message.