### PR TITLE
Fix the OpenAPI spec CollectionMetadata to include offset and limit

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -392,9 +392,15 @@ class OpenapiGenerator
     }
 
     schemas["CollectionMetadata"] = {
-      "type" => "object",
+      "type"       => "object",
       "properties" => {
-        "count" => {
+        "count"  => {
+          "type" => "integer"
+        },
+        "offset" => {
+          "type" => "integer"
+        },
+        "limit"  => {
           "type" => "integer"
         }
       }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3110,6 +3110,12 @@
         "properties": {
           "count": {
             "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
           }
         }
       },


### PR DESCRIPTION
Fix the openapi generate rake take and openapi spec so that
the collection metadata includes the offset and limit