### PR TITLE
All attrs :extra should be type object

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -3826,7 +3826,7 @@
           },
           "extra": {
             "readOnly": true,
-            "type": "string"
+            "type": "object"
           },
           "id": {
             "$ref": "#/components/schemas/ID"
@@ -4093,7 +4093,7 @@
           "extra": {
             "description": "Extra information about this object in JSON format",
             "readOnly": true,
-            "type": "string"
+            "type": "object"
           },
           "id": {
             "$ref": "#/components/schemas/ID"
@@ -4203,7 +4203,7 @@
           "extra": {
             "description": "Extra information about this object in JSON format",
             "readOnly": true,
-            "type": "string"
+            "type": "object"
           },
           "id": {
             "$ref": "#/components/schemas/ID"
@@ -4364,7 +4364,7 @@
           "extra": {
             "description": "Extra information about this object in JSON format",
             "readOnly": true,
-            "type": "string"
+            "type": "object"
           },
           "id": {
             "$ref": "#/components/schemas/ID"
@@ -4659,7 +4659,7 @@
           },
           "extra": {
             "readOnly": true,
-            "type": "string"
+            "type": "object"
           },
           "flavor_id": {
             "$ref": "#/components/schemas/ID"
@@ -4771,7 +4771,7 @@
           },
           "extra": {
             "readOnly": true,
-            "type": "string"
+            "type": "object"
           },
           "id": {
             "$ref": "#/components/schemas/ID"
@@ -4893,7 +4893,7 @@
           },
           "extra": {
             "readOnly": true,
-            "type": "string"
+            "type": "object"
           },
           "id": {
             "$ref": "#/components/schemas/ID"


### PR DESCRIPTION
In general all jsonb should be "object" or "array" types, if it's
string, the generated client deserializes it with .to_s, which
breaks the value.