### PR TITLE
Fix in permitting correct task's context

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -22,7 +22,7 @@ module Api
         permitted = api_doc_definition.all_attributes - api_doc_definition.read_only_attributes
         if body_params['context'].present?
           permitted.delete('context')
-          permitted << { "context" => {} }
+          permitted << {'context'=>{}}
         end
         body_params.permit(*permitted)
       end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -15,6 +15,17 @@ module Api
 
         head :no_content
       end
+
+      private
+
+      def params_for_update
+        permitted = api_doc_definition.all_attributes - api_doc_definition.read_only_attributes
+        if body_params['context'].present?
+          permitted.delete('context')
+          permitted << { "context" => {} }
+        end
+        body_params.permit(*permitted)
+      end
     end
   end
 end

--- a/spec/controllers/api/v1x0/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1x0/tasks_controller_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe Api::V1x0::TasksController, :type => :request do
   end
 
   it "patch /tasks/:id updates a Task" do
-    task = Task.create!(:state => "running", :status => "ok", :context => "context1", :tenant => tenant)
+    task = Task.create!(:state => "running", :status => "ok", :context => { :message => "context1" }, :tenant => tenant)
     expect(client).to receive(:publish_topic).with(
       :service => "platform.topological-inventory.task-output-stream",
       :event   => "Task.update",
-      :payload => {"state" => "completed", "status" => "ok", "context" => "context2", "task_id" => task.id.to_s}
+      :payload => {"state" => "completed", "status" => "ok", "context" => { :message => "context2" }, "task_id" => task.id.to_s}
     )
 
-    patch(api_v1x0_task_url(task.id), :params => {:state => "completed", :status => "ok", :context => "context2"}.to_json, :headers => headers)
+    patch(api_v1x0_task_url(task.id), :params => {:state => "completed", :status => "ok", :context => { :message => "context2" }}.to_json, :headers => headers)
 
     expect(task.reload.state).to eq("completed")
     expect(task.reload.status).to eq("ok")
-    expect(task.context).to eq("context2")
+    expect(task.context).to eq("message" => "context2")
 
     expect(response.status).to eq(204)
     expect(response.parsed_body).to be_empty


### PR DESCRIPTION
When sending `Task.context` in correct format then params are parsed by controller as
`<ActionController::Parameters {"context"=><ActionController::Parameters {"service_instance"=>{"source_id"=>"4", "source_ref"=>162}, "remote_status"=>"running"} permitted: false>, "state"=>"running", "status"=>"ok"} permitted: false>`

Then `body_params.permit("context")` is ignored, common `params_for_update` doesn't work.

**depends on** https://github.com/ManageIQ/topological_inventory-api-client-ruby/pull/15
**depends on** https://github.com/ManageIQ/topological_inventory-openshift/pull/96
**depends on** https://github.com/ManageIQ/topological_inventory-ansible_tower/pull/20

(cyclic dependencies)