### PR TITLE
ServiceOffering ordering

### DIFF
--- a/app/controllers/api/v1/mixins/sources_api_mixin.rb
+++ b/app/controllers/api/v1/mixins/sources_api_mixin.rb
@@ -1,0 +1,35 @@
+module Api
+  module V1
+    module Mixins
+      module SourcesApiMixin
+        def sources_api_client
+          @sources_api_client ||=
+            begin
+              identity = { 'x-rh-identity' => request.headers.fetch('x-rh-identity') }
+              api_client = SourcesApiClient::ApiClient.new
+              api_client.default_headers.merge!(identity)
+              SourcesApiClient::DefaultApi.new(api_client)
+            end
+        end
+
+        def retrieve_source_type(service_plan)
+          source = sources_api_client.show_source(service_plan.source_id.to_s)
+          if source.present?
+            source_type = sources_api_client.show_source_type(source.source_type_id.to_s)
+            if source_type.present?
+              source_type
+            else
+              raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source Type (ID #{source.source_type_id})")
+            end
+          else
+            raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source (ID #{service_plan.source_id})")
+          end
+
+        # Add message prefix to error
+        rescue SourcesApiClient::ApiError => err
+          raise SourcesApiClient::ApiError.new(:message => "Sources API: #{err.message} (code #{err.code})")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -3,6 +3,78 @@ module Api
     class ServiceOfferingsController < ApplicationController
       include Api::V1::Mixins::IndexMixin
       include Api::V1::Mixins::ShowMixin
+
+      def order
+        service_offering = model.find(params_for_order[:service_offering_id].to_i)
+        service_plan = model.where(:id => params_for_order[:service_plan_id].to_i).first if params_for_order[:service_plan_id].present?
+
+        source_type = retrieve_source_type(service_offering)
+        task = Task.create!(:tenant => service_offering.tenant, :state => "pending", :status => "ok")
+
+        messaging_client.publish_topic(
+          :service => "platform.topological-inventory.operations-#{source_type.name}",
+          :event   => "ServiceOffering.order",
+          :payload => payload_for_order(task, service_offering, service_plan)
+        )
+
+        render :json => {:task_id => task.id}
+      rescue ActiveRecord::RecordNotFound
+        head :bad_request
+      rescue StandardError => err
+        error_document = ManageIQ::API::Common::ErrorDocument.new.add(err.message)
+        render :json => error_document.to_h, :status => error_document.status
+      end
+
+      private
+
+      def sources_api_client
+        @sources_api_client ||=
+          begin
+            identity = { 'x-rh-identity' => request.headers.fetch('x-rh-identity') }
+            api_client = SourcesApiClient::ApiClient.new
+            api_client.default_headers.merge!(identity)
+            SourcesApiClient::DefaultApi.new(api_client)
+          end
+      end
+
+      def retrieve_source_type(service_plan)
+        source = sources_api_client.show_source(service_plan.source_id.to_s)
+        if source.present?
+          source_type = sources_api_client.show_source_type(source.source_type_id.to_s)
+          if source_type.present?
+            source_type
+          else
+            raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source Type (ID #{source.source_type_id.to_s})")
+          end
+        else
+          raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source (ID #{service_plan.source_id.to_s})")
+        end
+
+          # Add Sources API message prefix
+      rescue SourcesApiClient::ApiError => err
+        raise SourcesApiClient::ApiError.new(:message => "Sources API: #{err.message} (code #{err.code})")
+      end
+
+      def params_for_order
+        @params_for_order ||= params.permit(
+          :service_offering_id,
+          :service_plan_id,
+          :service_parameters          => {},
+          :provider_control_parameters => {}
+        ).to_h
+      end
+
+      def payload_for_order(task, service_offering, service_plan)
+        {
+          :request_context => ManageIQ::API::Common::Request.current_forwardable,
+          :params          => {
+            :order_params    => params_for_order,
+            :service_offering_id => service_offering.id.to_s,
+            :service_plan_id => service_plan&.id.to_s,
+            :task_id         => task.id.to_s,
+          }
+        }
+      end
     end
   end
 end

--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -3,10 +3,10 @@ module Api
     class ServiceOfferingsController < ApplicationController
       include Api::V1::Mixins::IndexMixin
       include Api::V1::Mixins::ShowMixin
+      include Api::V1::Mixins::SourcesApiMixin
 
       def order
         service_offering = model.find(params_for_order[:service_offering_id].to_i)
-        service_plan = model.where(:id => params_for_order[:service_plan_id].to_i).first if params_for_order[:service_plan_id].present?
 
         source_type = retrieve_source_type(service_offering)
         task = Task.create!(:tenant => service_offering.tenant, :state => "pending", :status => "ok")
@@ -14,7 +14,7 @@ module Api
         messaging_client.publish_topic(
           :service => "platform.topological-inventory.operations-#{source_type.name}",
           :event   => "ServiceOffering.order",
-          :payload => payload_for_order(task, service_offering, service_plan)
+          :payload => payload_for_order(task, service_offering)
         )
 
         render :json => {:task_id => task.id}
@@ -27,51 +27,21 @@ module Api
 
       private
 
-      def sources_api_client
-        @sources_api_client ||=
-          begin
-            identity = { 'x-rh-identity' => request.headers.fetch('x-rh-identity') }
-            api_client = SourcesApiClient::ApiClient.new
-            api_client.default_headers.merge!(identity)
-            SourcesApiClient::DefaultApi.new(api_client)
-          end
-      end
-
-      def retrieve_source_type(service_plan)
-        source = sources_api_client.show_source(service_plan.source_id.to_s)
-        if source.present?
-          source_type = sources_api_client.show_source_type(source.source_type_id.to_s)
-          if source_type.present?
-            source_type
-          else
-            raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source Type (ID #{source.source_type_id.to_s})")
-          end
-        else
-          raise SourcesApiClient::ApiError.new(:message => "Error retrieving Source (ID #{service_plan.source_id.to_s})")
-        end
-
-          # Add Sources API message prefix
-      rescue SourcesApiClient::ApiError => err
-        raise SourcesApiClient::ApiError.new(:message => "Sources API: #{err.message} (code #{err.code})")
-      end
-
       def params_for_order
         @params_for_order ||= params.permit(
           :service_offering_id,
-          :service_plan_id,
           :service_parameters          => {},
           :provider_control_parameters => {}
         ).to_h
       end
 
-      def payload_for_order(task, service_offering, service_plan)
+      def payload_for_order(task, service_offering)
         {
           :request_context => ManageIQ::API::Common::Request.current_forwardable,
           :params          => {
-            :order_params    => params_for_order,
+            :order_params        => params_for_order,
             :service_offering_id => service_offering.id.to_s,
-            :service_plan_id => service_plan&.id.to_s,
-            :task_id         => task.id.to_s,
+            :task_id             => task.id.to_s,
           }
         }
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
         resources :tags,    :only => [:index]
       end
       resources :service_offerings,       :only => [:index, :show] do
+        post "order", :to => "service_offerings#order"
         resources :service_instances, :only => [:index]
         resources :service_plans,     :only => [:index]
         resources :tags,              :only => [:index]

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -6426,6 +6426,12 @@
           "source_ref": {
             "type": "string"
           },
+          "source_region_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "subscription_id": {
+            "$ref": "#/components/schemas/ID"
+          },
           "updated_at": {
             "format": "date-time",
             "readOnly": true,
@@ -6499,6 +6505,9 @@
             "title": "Name",
             "type": "string"
           },
+          "parent_orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
           "source_created_at": {
             "format": "date-time",
             "readOnly": true,
@@ -6516,6 +6525,12 @@
             "format": "uuid",
             "readOnly": true,
             "type": "string"
+          },
+          "source_region_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "subscription_id": {
+            "$ref": "#/components/schemas/ID"
           },
           "updated_at": {
             "format": "date-time",
@@ -7011,6 +7026,9 @@
           "id": {
             "$ref": "#/components/schemas/ID"
           },
+          "refresh_status": {
+            "type": "string"
+          },
           "uid": {
             "readOnly": true,
             "title": "Unique ID of the inventory source installation",
@@ -7482,6 +7500,12 @@
             "readOnly": true,
             "type": "string"
           },
+          "source_region_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "subscription_id": {
+            "$ref": "#/components/schemas/ID"
+          },
           "uid_ems": {
             "description": "Cross-Source Unique Reference",
             "readOnly": true,
@@ -7541,6 +7565,9 @@
             "readOnly": true,
             "type": "string"
           },
+          "orchestration_stack_id": {
+            "$ref": "#/components/schemas/ID"
+          },
           "size": {
             "description": "Size of the volume in bytes",
             "example": 8589934592,
@@ -7571,6 +7598,9 @@
             "example": "in-use",
             "readOnly": true,
             "type": "string"
+          },
+          "subscription_id": {
+            "$ref": "#/components/schemas/ID"
           },
           "updated_at": {
             "format": "date-time",

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2018,30 +2018,43 @@
     },
     "/service_offerings/{id}/order": {
       "post": {
-        "summary": "Create a new ServiceOffering",
-        "operationId": "createServiceOffering",
-        "description": "Creates a ServiceOffering object",
+        "summary": "Order an existing ServiceOffering",
+        "operationId": "orderServiceOffering",
+        "description": "Returns a Task id",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ServiceOffering"
+                "$ref": "#/components/schemas/OrderParameters"
               }
             }
           },
-          "description": "ServiceOffering attributes to create",
+          "description": "Order parameters defining the service and provider control",
           "required": true
         },
         "responses": {
-          "201": {
-            "description": "ServiceOffering creation successful",
+          "200": {
+            "description": "Returns a task ID for the order",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ServiceOffering"
+                  "type": "object",
+                  "properties": {
+                    "task_id": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
+          },
+          "400": {
+            "description": "BadRequest"
           }
         }
       }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2016,6 +2016,36 @@
         }
       }
     },
+    "/service_offerings/{id}/order": {
+      "post": {
+        "summary": "Create a new ServiceOffering",
+        "operationId": "createServiceOffering",
+        "description": "Creates a ServiceOffering object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServiceOffering"
+              }
+            }
+          },
+          "description": "ServiceOffering attributes to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "ServiceOffering creation successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceOffering"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/service_offerings/{id}/service_instances": {
       "get": {
         "summary": "List ServiceInstances for ServiceOffering",
@@ -6396,12 +6426,6 @@
           "source_ref": {
             "type": "string"
           },
-          "source_region_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "subscription_id": {
-            "$ref": "#/components/schemas/ID"
-          },
           "updated_at": {
             "format": "date-time",
             "readOnly": true,
@@ -6475,9 +6499,6 @@
             "title": "Name",
             "type": "string"
           },
-          "parent_orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
-          },
           "source_created_at": {
             "format": "date-time",
             "readOnly": true,
@@ -6495,12 +6516,6 @@
             "format": "uuid",
             "readOnly": true,
             "type": "string"
-          },
-          "source_region_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "subscription_id": {
-            "$ref": "#/components/schemas/ID"
           },
           "updated_at": {
             "format": "date-time",
@@ -6996,9 +7011,6 @@
           "id": {
             "$ref": "#/components/schemas/ID"
           },
-          "refresh_status": {
-            "type": "string"
-          },
           "uid": {
             "readOnly": true,
             "title": "Unique ID of the inventory source installation",
@@ -7470,12 +7482,6 @@
             "readOnly": true,
             "type": "string"
           },
-          "source_region_id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "subscription_id": {
-            "$ref": "#/components/schemas/ID"
-          },
           "uid_ems": {
             "description": "Cross-Source Unique Reference",
             "readOnly": true,
@@ -7535,9 +7541,6 @@
             "readOnly": true,
             "type": "string"
           },
-          "orchestration_stack_id": {
-            "$ref": "#/components/schemas/ID"
-          },
           "size": {
             "description": "Size of the volume in bytes",
             "example": 8589934592,
@@ -7568,9 +7571,6 @@
             "example": "in-use",
             "readOnly": true,
             "type": "string"
-          },
-          "subscription_id": {
-            "$ref": "#/components/schemas/ID"
           },
           "updated_at": {
             "format": "date-time",


### PR DESCRIPTION
Provides ordering of offerings with or without plan(form)

- old way
  - `POST /service_plans/:service_plan_id/order "{ \"service_parameters\": {...}", \"provider_controler_parameters\":{}}"`
- new way
  - `POST /service_offerings/:service_offering_id/order "{\"provider_controler_parameters\":{}}`
  - `POST /service_offerings/:service_offering_id/order "{\"service_parameters\": {...}", \"provider_controler_parameters\":{}}"`

**depends on**:
- [x] https://github.com/ManageIQ/topological_inventory-openshift/pull/99
- [x] https://github.com/ManageIQ/topological_inventory-ansible_tower/pull/24

**dependents**:
https://github.com/ManageIQ/topological_inventory-api-client-ruby/pull/16