### PR TITLE
Added optional service_plan_id to ServiceOffering#order

### DIFF
--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -30,13 +30,14 @@ module Api
       def params_for_order
         @params_for_order ||= params.permit(
           :service_offering_id,
+          :service_plan_id,
           :service_parameters          => {},
           :provider_control_parameters => {}
         ).to_h
       end
 
       def payload_for_order(task, service_offering)
-        {
+        payload = {
           :request_context => ManageIQ::API::Common::Request.current_forwardable,
           :params          => {
             :order_params        => params_for_order,
@@ -44,6 +45,8 @@ module Api
             :task_id             => task.id.to_s,
           }
         }
+        payload[:params][:service_plan_id] = params_for_order[:service_plan_id].to_s if params_for_order[:service_plan_id].present?
+        payload
       end
     end
   end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -2030,7 +2030,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/OrderParameters"
+                "$ref": "#/components/schemas/OrderParametersServiceOffering"
               }
             }
           },
@@ -2229,7 +2229,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/OrderParameters"
+                "$ref": "#/components/schemas/OrderParametersServicePlan"
               }
             }
           },
@@ -6569,7 +6569,7 @@
           }
         }
       },
-      "OrderParameters": {
+      "OrderParametersServiceOffering": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -6580,6 +6580,32 @@
           "provider_control_parameters": {
             "type": "object",
             "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys"
+          },
+          "service_offering_id": {
+            "$ref": "#/components/schemas/ID",
+            "required": true
+          },
+          "service_plan_id": {
+            "$ref": "#/components/schemas/ID",
+            "required": false
+          }
+        }
+      },
+      "OrderParametersServicePlan": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "service_parameters": {
+            "type": "object",
+            "description": "JSON object with provisioning parameters"
+          },
+          "provider_control_parameters": {
+            "type": "object",
+            "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys"
+          },
+          "service_plan_id": {
+            "$ref": "#/components/schemas/ID",
+            "required": true
           }
         }
       },


### PR DESCRIPTION
ServicePlan's id is not important for ansible tower ordering, but it's needed for openshift operations, where it's ordered by SvcOffering.name and SvcPlan.name

Fixes https://github.com/ManageIQ/topological_inventory-api/pull/235