### PR TITLE
Update openapi-generator-cli version to 4.1.1

### DIFF
--- a/lib/tasks/client_generate.rake
+++ b/lib/tasks/client_generate.rake
@@ -6,7 +6,7 @@ class ClientGenerator
   require 'json'
   require 'uri'
 
-  VERSION = "3.3.4".freeze
+  VERSION = "4.1.1".freeze
   SOURCE_URL = "http://central.maven.org/maven2/org/openapitools/openapi-generator-cli".freeze
 
   def msg(message)


### PR DESCRIPTION
The 4.1.1 version of openapi-generator-cli was released and we're a few
versions behind.