### PR TITLE
Collect the storage.ems_ref

### DIFF
--- a/config/cfme/manifest_5_11.json
+++ b/config/cfme/manifest_5_11.json
@@ -191,6 +191,7 @@
       },
       "storages": {
         "id": null,
+        "ems_ref": null,
         "name": null,
         "location": null,
         "store_type": null,
@@ -332,6 +333,7 @@
       },
       "storages": {
         "id": null,
+        "ems_ref": null,
         "name": null,
         "location": null,
         "store_type": null,


### PR DESCRIPTION
RHV doesn't set the ems_ref on the host_storages record like VMware
does, so we need to get the storage.ems_ref for RHV datastores.