### PR TITLE
Remove redundant svc offering openapi params

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -406,15 +406,34 @@ class OpenapiGenerator
       }
     }
 
-    schemas["OrderParameters"] = {
-      "type" => "object",
-      "properties" => {
-        "service_parameters" => {
-          "type" => "object",
+    schemas["OrderParametersServiceOffering"] = {
+      "type"                 => "object",
+      "additionalProperties" => false,
+      "properties"           => {
+        "service_parameters"          => {
+          "type"        => "object",
           "description" => "JSON object with provisioning parameters"
         },
         "provider_control_parameters" => {
-          "type" => "object",
+          "type"        => "object",
+          "description" => "The provider specific parameters needed to provision this service. This might include namespaces, special keys"
+        },
+        "service_plan_id"             => {
+          "$ref" => "##{SCHEMAS_PATH}/ID"
+        }
+      }
+    }
+
+    schemas["OrderParametersServicePlan"] = {
+      "type"                 => "object",
+      "additionalProperties" => false,
+      "properties"           => {
+        "service_parameters"          => {
+          "type"        => "object",
+          "description" => "JSON object with provisioning parameters"
+        },
+        "provider_control_parameters" => {
+          "type"        => "object",
           "description" => "The provider specific parameters needed to provision this service. This might include namespaces, special keys"
         }
       }

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -6581,13 +6581,8 @@
             "type": "object",
             "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys"
           },
-          "service_offering_id": {
-            "$ref": "#/components/schemas/ID",
-            "required": true
-          },
           "service_plan_id": {
-            "$ref": "#/components/schemas/ID",
-            "required": false
+            "$ref": "#/components/schemas/ID"
           }
         }
       },
@@ -6602,10 +6597,6 @@
           "provider_control_parameters": {
             "type": "object",
             "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys"
-          },
-          "service_plan_id": {
-            "$ref": "#/components/schemas/ID",
-            "required": true
           }
         }
       },


### PR DESCRIPTION
`OrderParametersServiceOffering` doesn't need `service_offering_id` in properties because this is already defined as `id`.
The same for `OrderParametersServicePlan` and `service_plan_id`.
And `required: false` is default value so it's useless definition.

- **dependent**: https://github.com/ManageIQ/topological_inventory-api-client-ruby/pull/19