### PR TITLE
Fix a potential caching issue with db:migrate+seed

### DIFF
--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -28,5 +28,6 @@ write_encryption_key
 # Wait for postgres to be ready
 check_svc_status $DATABASE_HOST $DATABASE_PORT
 
-bundle exec rake db:migrate db:seed
+bundle exec rake db:migrate
+bundle exec rake db:seed
 bundle exec rails server


### PR DESCRIPTION
There is a potential caching issue with running db:migrate and db:seed
in the same rake invocation.  The seed task has a cached schema and thus
doesn't pick up recent changes to the models.