### PR TITLE
Add a content type to /openapi.json

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1402,7 +1402,14 @@
         "operationId": "getDocumentation",
         "responses": {
           "200": {
-            "description": "The API document for this version of the API"
+            "description": "The API document for this version of the API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Add a return content type to getDocumentation to get /openapi.json so
that generated API clients return the content.

Similar to https://github.com/ManageIQ/sources-api/pull/91
Client PR: https://github.com/ManageIQ/topological_inventory-api-client-ruby/pull/20