### PR TITLE
Update manageiq-api-common

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem 'jbuilder',            '~> 2.0'
 gem 'json-schema',         '~> 2.8'
-gem 'manageiq-api-common', '~> 0.1.0'
+gem 'manageiq-api-common', '~> 1.0', '>= 1.0.2'
 gem 'manageiq-loggers',    '~> 0.1'
 gem 'manageiq-messaging',  '~> 0.1.2', :require => false
 gem 'manageiq-password',   '~> 0.2', ">= 0.2.1"


### PR DESCRIPTION
Fixes TPINVTRY-639

Also pulls in v1.0.0 changes:
### Breaking Changes
- Namespace dynamically defined GraphQL API version modules under ManageIQ::API::Common::GraphQL::Api #105

### Added
- New entitlements for Ansible and Migrations #113 and use them #115
- Forwarding of persona headers #109

### Changed
- Extract GraphQLRequest to a schema object rather than inline #110
- Update to openapi_parser v0.5.0 #108

### Fixed
- Fixed errors around already defined constants in GraphQL #112
- Allow GraphQL generator to support paths with IDs like /primary/{primary_id}/ #107
- Constant problems related to GraphQL namespace #105
